### PR TITLE
Token calls - Not Required for Private App

### DIFF
--- a/example/private/get.cfm
+++ b/example/private/get.cfm
@@ -2,9 +2,6 @@
 ----------------------------------------------------------------------------
 1) Hit some Xero endpoints and show the response
 --->
-<cfif NOT StructKeyExists(session, "stToken")>
-	<cflocation url="index.cfm">
-</cfif>
 
 <html>
 <head>
@@ -15,8 +12,6 @@
 <body>
 	<cfinclude template="/common/resource.cfm">
 
-	<cfset sRequestToken = session.stToken["oauth_token"]> <!--- returned after an access token call --->
-	<cfset sRequestTokenSecret = session.stToken["oauth_token_secret"]> <!--- returned after an access token call --->
 	<cfset sResourceEndpoint = "#sApiEndpoint##form.endpoint#">
 	
 	<cfset stParameters = structNew()>


### PR DESCRIPTION
Removed lines for token calls as these are not required for Private Apps.
