### PR TITLE
Linux casing fix

### DIFF
--- a/model/Invoice.cfc
+++ b/model/Invoice.cfc
@@ -565,7 +565,7 @@
 		   <cfscript>
             var arr = ArrayNew(1);
             for (var i=1;i LTE ArrayLen(arguments.Lineitems);i=i+1) {
-              var item=createObject("component","cfc.model.Lineitem").init().populate(arguments.Lineitems[i]); 
+              var item=createObject("component","cfc.model.LineItem").init().populate(arguments.Lineitems[i]); 
               ArrayAppend(arr,item);
             }
       </cfscript>


### PR DESCRIPTION
There is a casing issue when using the Xero-CFML sdk on Linux. In Invoice.cfc on Line 568 there is a reference to cfc.model.Lineitem. The file, however is called LineItem.cfc and therefore cannot be found. The fix changes cfc.model.Lineitem to cfc.model.LineItem to match the filename.