### PR TITLE
Change in API wrapper structure

### DIFF
--- a/config.cfc
+++ b/config.cfc
@@ -131,7 +131,7 @@ History:
 		<cfif structKeyExists(this.json, "PrivateKeyCert")>
 			<cfset this.PathToPrivateKey = pathToConfig & this.json["PrivateKeyCert"]>
 			<cfif NOT FileExists(this.PathToPrivateKey)>
-				<cfoutput>No Private Key File Found	- Check the path set in /resource/config.json - #this.PathToPrivateKey#</cfoutput>
+				<cfoutput>No Private Key File Found	- Check the path set in #pathToConfigJSON# - #this.PathToPrivateKey#</cfoutput>
 				<cfabort>
 			</cfif>
 		</cfif>

--- a/model/Account.cfc
+++ b/model/Account.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Account" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Account" output="false" extends="xeroclient"
   hint="I am the Account Class.">
 
 <!--- PROPERTIES --->
@@ -22,10 +22,13 @@
   <cfproperty name="HasAttachments" type="Boolean" default="" />
   <cfproperty name="UpdatedDateUTC" type="String" default="" />
 
+  
+
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Account Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -83,98 +86,98 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.AccountID=getAccountID();
-            myStruct.Status=getStatus();
+            myStruct["AccountID"]=getAccountID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Code")) {
               if (NOT listFindNoCase(arguments.exclude, "Code")) {
-                myStruct.Code=getCode();
+                myStruct["Code"]=getCode();
               }
             }
             if (structKeyExists(variables.instance,"Name")) {
               if (NOT listFindNoCase(arguments.exclude, "Name")) {
-                myStruct.Name=getName();
+                myStruct["Name"]=getName();
               }
             }
             if (structKeyExists(variables.instance,"Type")) {
               if (NOT listFindNoCase(arguments.exclude, "Type")) {
-                myStruct.Type=getType();
+                myStruct["Type"]=getType();
               }
             }
             if (structKeyExists(variables.instance,"BankAccountNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "BankAccountNumber")) {
-                myStruct.BankAccountNumber=getBankAccountNumber();
+                myStruct["BankAccountNumber"]=getBankAccountNumber();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"Description")) {
               if (NOT listFindNoCase(arguments.exclude, "Description")) {
-                myStruct.Description=getDescription();
+                myStruct["Description"]=getDescription();
               }
             }
             if (structKeyExists(variables.instance,"BankAccountType")) {
               if (NOT listFindNoCase(arguments.exclude, "BankAccountType")) {
-                myStruct.BankAccountType=getBankAccountType();
+                myStruct["BankAccountType"]=getBankAccountType();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyCode")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyCode")) {
-                myStruct.CurrencyCode=getCurrencyCode();
+                myStruct["CurrencyCode"]=getCurrencyCode();
               }
             }
             if (structKeyExists(variables.instance,"TaxType")) {
               if (NOT listFindNoCase(arguments.exclude, "TaxType")) {
-                myStruct.TaxType=getTaxType();
+                myStruct["TaxType"]=getTaxType();
               }
             }
             if (structKeyExists(variables.instance,"EnablePaymentsToAccount")) {
               if (NOT listFindNoCase(arguments.exclude, "EnablePaymentsToAccount")) {
-                myStruct.EnablePaymentsToAccount=getEnablePaymentsToAccount();
+                myStruct["EnablePaymentsToAccount"]=getEnablePaymentsToAccount();
               }
             }
             if (structKeyExists(variables.instance,"ShowInExpenseClaims")) {
               if (NOT listFindNoCase(arguments.exclude, "ShowInExpenseClaims")) {
-                myStruct.ShowInExpenseClaims=getShowInExpenseClaims();
+                myStruct["ShowInExpenseClaims"]=getShowInExpenseClaims();
               }
             }
             if (structKeyExists(variables.instance,"AccountID")) {
               if (NOT listFindNoCase(arguments.exclude, "AccountID")) {
-                myStruct.AccountID=getAccountID();
+                myStruct["AccountID"]=getAccountID();
               }
             }
             if (structKeyExists(variables.instance,"Class")) {
               if (NOT listFindNoCase(arguments.exclude, "Class")) {
-                myStruct.Class=getAccountClass();
+                myStruct["Class"]=getAccountClass();
               }
             }
             if (structKeyExists(variables.instance,"SystemAccount")) {
               if (NOT listFindNoCase(arguments.exclude, "SystemAccount")) {
-                myStruct.SystemAccount=getSystemAccount();
+                myStruct["SystemAccount"]=getSystemAccount();
               }
             }
             if (structKeyExists(variables.instance,"ReportingCode")) {
               if (NOT listFindNoCase(arguments.exclude, "ReportingCode")) {
-                myStruct.ReportingCode=getReportingCode();
+                myStruct["ReportingCode"]=getReportingCode();
               }
             }
             if (structKeyExists(variables.instance,"ReportingCodeName")) {
               if (NOT listFindNoCase(arguments.exclude, "ReportingCodeName")) {
-                myStruct.ReportingCodeName=getReportingCodeName();
+                myStruct["ReportingCodeName"]=getReportingCodeName();
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
-                myStruct.HasAttachments=getHasAttachments();
+                myStruct["HasAttachments"]=getHasAttachments();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
           }

--- a/model/Address.cfc
+++ b/model/Address.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Address" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Address" output="false" extends="xeroclient"
   hint="I am the Address Class.">
 
 <!--- PROPERTIES --->
@@ -16,7 +16,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Address Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -61,57 +62,57 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.AddressID=getAddressID();
-            myStruct.Status=getStatus();
+            myStruct["AddressID"]=getAddressID();
+            myStruct["Status"]=getStatus();
           } else {
             if (structKeyExists(variables.instance,"AddressType")) {
               if (NOT listFindNoCase(arguments.exclude, "AddressType")) {
-                myStruct.AddressType=getAddressType();
+                myStruct["AddressType"]=getAddressType();
               }
             }
             if (structKeyExists(variables.instance,"AddressLine1")) {
               if (NOT listFindNoCase(arguments.exclude, "AddressLine1")) {
-                myStruct.AddressLine1=getAddressLine1();
+                myStruct["AddressLine1"]=getAddressLine1();
               }
             }
             if (structKeyExists(variables.instance,"AddressLine2")) {
               if (NOT listFindNoCase(arguments.exclude, "AddressLine2")) {
-                myStruct.AddressLine2=getAddressLine2();
+                myStruct["AddressLine2"]=getAddressLine2();
               }
             }
             if (structKeyExists(variables.instance,"AddressLine3")) {
               if (NOT listFindNoCase(arguments.exclude, "AddressLine3")) {
-                myStruct.AddressLine3=getAddressLine3();
+                myStruct["AddressLine3"]=getAddressLine3();
               }
             }
             if (structKeyExists(variables.instance,"AddressLine4")) {
               if (NOT listFindNoCase(arguments.exclude, "AddressLine4")) {
-                myStruct.AddressLine4=getAddressLine4();
+                myStruct["AddressLine4"]=getAddressLine4();
               }
             }
             if (structKeyExists(variables.instance,"City")) {
               if (NOT listFindNoCase(arguments.exclude, "City")) {
-                myStruct.City=getCity();
+                myStruct["City"]=getCity();
               }
             }
             if (structKeyExists(variables.instance,"Region")) {
               if (NOT listFindNoCase(arguments.exclude, "Region")) {
-                myStruct.Region=getRegion();
+                myStruct["Region"]=getRegion();
               }
             }
             if (structKeyExists(variables.instance,"PostalCode")) {
               if (NOT listFindNoCase(arguments.exclude, "PostalCode")) {
-                myStruct.PostalCode=getPostalCode();
+                myStruct["PostalCode"]=getPostalCode();
               }
             }
             if (structKeyExists(variables.instance,"Country")) {
               if (NOT listFindNoCase(arguments.exclude, "Country")) {
-                myStruct.Country=getCountry();
+                myStruct["Country"]=getCountry();
               }
             }
             if (structKeyExists(variables.instance,"AttentionTo")) {
               if (NOT listFindNoCase(arguments.exclude, "AttentionTo")) {
-                myStruct.AttentionTo=getAttentionTo();
+                myStruct["AttentionTo"]=getAttentionTo();
               }
             }
           }

--- a/model/Allocation.cfc
+++ b/model/Allocation.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Allocation" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Allocation" output="false" extends="xeroclient"
   hint="I am the Allocation Class.">
 
 <!--- PROPERTIES --->
@@ -9,7 +9,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Allocation Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>      
     <cfreturn this />
   </cffunction>
 
@@ -38,18 +39,18 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.AllocationID=getAllocationID();
-            myStruct.Status=getStatus();
+            myStruct["AllocationID"]=getAllocationID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"AppliedAmount")) {
               if (NOT listFindNoCase(arguments.exclude, "AppliedAmount")) {
-                myStruct.AppliedAmount=getAppliedAmount();
+                myStruct["AppliedAmount"]=getAppliedAmount();
               }
             }
             if (structKeyExists(variables.instance,"Date")) {
               if (NOT listFindNoCase(arguments.exclude, "Date")) {
-                myStruct.Date=getDate();
+                myStruct["Date"]=getDate();
               }
             }
           }

--- a/model/BankTransaction.cfc
+++ b/model/BankTransaction.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="BankTransaction" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="BankTransaction" output="false" extends="xeroclient"
   hint="I am the BankTransaction Class.">
 
 <!--- PROPERTIES --->
@@ -27,7 +27,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the BankTransaction Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>      
     <cfreturn this />
   </cffunction>
 
@@ -56,109 +57,109 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.BankTransactionID=getBankTransactionID();
-            myStruct.Status=getStatus();
+            myStruct["BankTransactionID"]=getBankTransactionID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Type")) {
               if (NOT listFindNoCase(arguments.exclude, "Type")) {
-                myStruct.Type=getType();
+                myStruct["Type"]=getType();
               }
             }
             if (structKeyExists(variables.instance,"Contact")) {
               if (NOT listFindNoCase(arguments.exclude, "Contact")) {
-                myStruct.Contact=getContact();
+                myStruct["Contact"]=getContact();
               }
             }
             if (structKeyExists(variables.instance,"BankAccount")) {
               if (NOT listFindNoCase(arguments.exclude, "BankAccount")) {
-                myStruct.BankAccount=getBankAccount();
+                myStruct["BankAccount"]=getBankAccount();
               }
             }
             if (structKeyExists(variables.instance,"Lineitems")) {
               if (NOT listFindNoCase(arguments.exclude, "Lineitems")) {
-                myStruct.Lineitems=getLineitems();
+                myStruct["Lineitems"]=getLineitems();
               }
             }
             if (structKeyExists(variables.instance,"IsReconciled")) {
               if (NOT listFindNoCase(arguments.exclude, "IsReconciled")) {
-                myStruct.IsReconciled=getIsReconciled();
+                myStruct["IsReconciled"]=getIsReconciled();
               }
             }
             if (structKeyExists(variables.instance,"Date")) {
               if (NOT listFindNoCase(arguments.exclude, "Date")) {
-                myStruct.Date=getDate();
+                myStruct["Date"]=getDate();
               }
             }
             if (structKeyExists(variables.instance,"Reference")) {
               if (NOT listFindNoCase(arguments.exclude, "Reference")) {
-                myStruct.Reference=getReference();
+                myStruct["Reference"]=getReference();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyCode")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyCode")) {
-                myStruct.CurrencyCode=getCurrencyCode();
+                myStruct["CurrencyCode"]=getCurrencyCode();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyRate")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyRate")) {
-                myStruct.CurrencyRate=getCurrencyRate();
+                myStruct["CurrencyRate"]=getCurrencyRate();
               }
             }
             if (structKeyExists(variables.instance,"Url")) {
               if (NOT listFindNoCase(arguments.exclude, "Url")) {
-                myStruct.Url=getUrl();
+                myStruct["Url"]=getUrl();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"LineAmountTypes")) {
               if (NOT listFindNoCase(arguments.exclude, "LineAmountTypes")) {
-                myStruct.LineAmountTypes=getLineAmountTypes();
+                myStruct["LineAmountTypes"]=getLineAmountTypes();
               }
             }
             if (structKeyExists(variables.instance,"SubTotal")) {
               if (NOT listFindNoCase(arguments.exclude, "SubTotal")) {
-                myStruct.SubTotal=getSubTotal();
+                myStruct["SubTotal"]=getSubTotal();
               }
             }
             if (structKeyExists(variables.instance,"TotalTax")) {
               if (NOT listFindNoCase(arguments.exclude, "TotalTax")) {
-                myStruct.TotalTax=getTotalTax();
+                myStruct["TotalTax"]=getTotalTax();
               }
             }
             if (structKeyExists(variables.instance,"Total")) {
               if (NOT listFindNoCase(arguments.exclude, "Total")) {
 
-                myStruct.Total=getTotal();
+                myStruct["Total"]=getTotal();
               }
             }
             if (structKeyExists(variables.instance,"BankTransactionID")) {
               if (NOT listFindNoCase(arguments.exclude, "BankTransactionID")) {
-                myStruct.BankTransactionID=getBankTransactionID();
+                myStruct["BankTransactionID"]=getBankTransactionID();
               }
             }
             if (structKeyExists(variables.instance,"PrepaymentID")) {
               if (NOT listFindNoCase(arguments.exclude, "PrepaymentID")) {
-                myStruct.PrepaymentID=getPrepaymentID();
+                myStruct["PrepaymentID"]=getPrepaymentID();
               }
             }
             if (structKeyExists(variables.instance,"OverpaymentID")) {
               if (NOT listFindNoCase(arguments.exclude, "OverpaymentID")) {
-                myStruct.OverpaymentID=getOverpaymentID();
+                myStruct["OverpaymentID"]=getOverpaymentID();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
-                myStruct.HasAttachments=getHasAttachments();
+                myStruct["HasAttachments"]=getHasAttachments();
               }
             }
           }
@@ -426,7 +427,7 @@
        <cfscript>
             var arr = ArrayNew(1);
             for (var i=1;i LTE ArrayLen(arguments.Lineitems);i=i+1) {
-              var item=createObject("component","cfc.model.Lineitem").init().populate(arguments.Lineitems[i]); 
+              var item=createObject("component","Lineitem").init(variables.xero).populate(arguments.Lineitems[i]); 
               ArrayAppend(arr,item);
             }
       </cfscript>

--- a/model/BankTransfer.cfc
+++ b/model/BankTransfer.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="BankTransfer" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="BankTransfer" output="false" extends="xeroclient"
   hint="I am the BankTransfer Class.">
 
 <!--- PROPERTIES --->
@@ -17,7 +17,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the BankTransfer Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>      
     <cfreturn this />
   </cffunction>
 
@@ -54,58 +55,58 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.BankTransferID=getBankTransferID();
-            myStruct.Status=getStatus();
+            myStruct["BankTransferID"]=getBankTransferID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"FromBankAccount")) {
               if (NOT listFindNoCase(arguments.exclude, "FromBankAccount")) {
-                myStruct.FromBankAccount=getFromBankAccount();
+                myStruct["FromBankAccount"]=getFromBankAccount();
               }
             }
             if (structKeyExists(variables.instance,"ToBankAccount")) {
               if (NOT listFindNoCase(arguments.exclude, "ToBankAccount")) {
-                myStruct.ToBankAccount=getToBankAccount();
+                myStruct["ToBankAccount"]=getToBankAccount();
               }
             }
             if (structKeyExists(variables.instance,"Amount")) {
               if (NOT listFindNoCase(arguments.exclude, "Amount")) {
-                myStruct.Amount=getAmount();
+                myStruct["Amount"]=getAmount();
               }
             }
             if (structKeyExists(variables.instance,"Date")) {
               if (NOT listFindNoCase(arguments.exclude, "Date")) {
-                myStruct.Date=getDate();
+                myStruct["Date"]=getDate();
               }
             }
             if (structKeyExists(variables.instance,"BankTransferID")) {
               if (NOT listFindNoCase(arguments.exclude, "BankTransferID")) {
-                myStruct.BankTransferID=getBankTransferID();
+                myStruct["BankTransferID"]=getBankTransferID();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyRate")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyRate")) {
-                myStruct.CurrencyRate=getCurrencyRate();
+                myStruct["CurrencyRate"]=getCurrencyRate();
               }
             }
             if (structKeyExists(variables.instance,"FromBankTransactionID")) {
               if (NOT listFindNoCase(arguments.exclude, "FromBankTransactionID")) {
-                myStruct.FromBankTransactionID=getFromBankTransactionID();
+                myStruct["FromBankTransactionID"]=getFromBankTransactionID();
               }
             }
             if (structKeyExists(variables.instance,"ToBankTransactionID")) {
               if (NOT listFindNoCase(arguments.exclude, "ToBankTransactionID")) {
-                myStruct.ToBankTransactionID=getToBankTransactionID();
+                myStruct["ToBankTransactionID"]=getToBankTransactionID();
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
-                myStruct.HasAttachments=getHasAttachments();
+                myStruct["HasAttachments"]=getHasAttachments();
               }
             }
             if (structKeyExists(variables.instance,"CreatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "CreatedDateUTC")) {
-                myStruct.CreatedDateUTC=getCreatedDateUTC();
+                myStruct["CreatedDateUTC"]=getCreatedDateUTC();
               }
             }
           }

--- a/model/BrandingTheme.cfc
+++ b/model/BrandingTheme.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="BrandingTheme" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="BrandingTheme" output="false" extends="xeroclient"
   hint="I am the BrandingTheme Class.">
 
 <!--- PROPERTIES --->
@@ -11,7 +11,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the BrandingTheme Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>      
     <cfreturn this />
   </cffunction>
 
@@ -40,28 +41,28 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.BrandingThemeID=getBrandingThemeID();
-            myStruct.Status=getStatus();
+            myStruct["BrandingThemeID"]=getBrandingThemeID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"BrandingThemeID")) {
               if (NOT listFindNoCase(arguments.exclude, "BrandingThemeID")) {
-                myStruct.BrandingThemeID=getBrandingThemeID();
+                myStruct["BrandingThemeID"]=getBrandingThemeID();
               }
             }
             if (structKeyExists(variables.instance,"Name")) {
               if (NOT listFindNoCase(arguments.exclude, "Name")) {
-                myStruct.Name=getName();
+                myStruct["Name"]=getName();
               }
             }
             if (structKeyExists(variables.instance,"SortOrder")) {
               if (NOT listFindNoCase(arguments.exclude, "SortOrder")) {
-                myStruct.SortOrder=getSortOrder();
+                myStruct["SortOrder"]=getSortOrder();
               }
             }
             if (structKeyExists(variables.instance,"CreatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "CreatedDateUTC")) {
-                myStruct.CreatedDateUTC=getCreatedDateUTC();
+                myStruct["CreatedDateUTC"]=getCreatedDateUTC();
               }
             }
           }

--- a/model/Contact.cfc
+++ b/model/Contact.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Contact" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Contact" output="false" extends="xeroclient"
   hint="I am the Contact Class.">
 
 <!--- PROPERTIES --->
@@ -40,7 +40,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Contact Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>      
     <cfreturn this />
   </cffunction>
 
@@ -88,238 +89,238 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.ContactID=getContactID();
-            myStruct.Status=getStatus();
+            myStruct["ContactID"]=getContactID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"ContactID")) {
               if (NOT listFindNoCase(arguments.exclude, "ContactID")) {
                 if (len(variables.instance.ContactID) GT 0) {
-                  myStruct.ContactID=getContactID();
+                  myStruct["ContactID"]=getContactID();
                 }
               }
             }
             if (structKeyExists(variables.instance,"ContactNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "ContactNumber")) {
                 if (len(variables.instance.ContactNumber) GT 0) {
-                  myStruct.ContactNumber=getContactNumber();
+                  myStruct["ContactNumber"]=getContactNumber();
                 }
               }
             }
             if (structKeyExists(variables.instance,"AccountNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "AccountNumber")) {
                 if (len(variables.instance.AccountNumber) GT 0) {
-                  myStruct.AccountNumber=getAccountNumber();
+                  myStruct["AccountNumber"]=getAccountNumber();
                 }
               }
             }
             if (structKeyExists(variables.instance,"ContactStatus")) {
               if (NOT listFindNoCase(arguments.exclude, "ContactStatus")) {
                 if (len(variables.instance.ContactStatus) GT 0) {
-                  myStruct.ContactStatus=getContactStatus();
+                  myStruct["ContactStatus"]=getContactStatus();
                 }
               }
             }
             if (structKeyExists(variables.instance,"Name")) {
               if (NOT listFindNoCase(arguments.exclude, "Name")) {
                 if (len(variables.instance.Name) GT 0) {
-                  myStruct.Name=getName();
+                  myStruct["Name"]=getName();
                 }
               }
             }
             if (structKeyExists(variables.instance,"FirstName")) {
               if (NOT listFindNoCase(arguments.exclude, "FirstName")) {
                 if (len(variables.instance.FirstName) GT 0) {
-                  myStruct.FirstName=getFirstName();
+                  myStruct["FirstName"]=getFirstName();
                 }
               }
             }
             if (structKeyExists(variables.instance,"LastName")) {
               if (NOT listFindNoCase(arguments.exclude, "LastName")) {
                 if (len(variables.instance.LastName) GT 0) {
-                  myStruct.LastName=getLastName();
+                  myStruct["LastName"]=getLastName();
                 }
               }
             }
             if (structKeyExists(variables.instance,"EmailAddress")) {
               if (NOT listFindNoCase(arguments.exclude, "EmailAddress")) {
                 if (len(variables.instance.EmailAddress) GT 0) {
-                  myStruct.EmailAddress=getEmailAddress();
+                  myStruct["EmailAddress"]=getEmailAddress();
                 }
               }
             }
             if (structKeyExists(variables.instance,"SkypeUserName")) {
               if (NOT listFindNoCase(arguments.exclude, "SkypeUserName")) {
                 if (len(variables.instance.SkypeUserName) GT 0) {
-                  myStruct.SkypeUserName=getSkypeUserName();
+                  myStruct["SkypeUserName"]=getSkypeUserName();
                 }
               }
             }
             if (structKeyExists(variables.instance,"ContactPersons")) {
               if (NOT listFindNoCase(arguments.exclude, "ContactPersons")) {
                 if (ArrayLen(variables.instance.ContactPersons) GT 0) {
-                  myStruct.ContactPersons=getContactPersons();
+                  myStruct["ContactPersons"]=getContactPersons();
                 }
               }
             }
             if (structKeyExists(variables.instance,"BankAccountDetails")) {
               if (NOT listFindNoCase(arguments.exclude, "BankAccountDetails")) {
                 if (len(variables.instance.BankAccountDetails) GT 0) {
-                  myStruct.BankAccountDetails=getBankAccountDetails();
+                  myStruct["BankAccountDetails"]=getBankAccountDetails();
                 }
               }
             }
             if (structKeyExists(variables.instance,"TaxNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "TaxNumber")) {
                 if (len(variables.instance.TaxNumber) GT 0) {
-                  myStruct.TaxNumber=getTaxNumber();
+                  myStruct["TaxNumber"]=getTaxNumber();
                 }
               }
             }
             if (structKeyExists(variables.instance,"AccountsReceivableTaxType")) {
               if (NOT listFindNoCase(arguments.exclude, "AccountsReceivableTaxType")) {
                 if (len(variables.instance.AccountsReceivableTaxType) GT 0) {
-                  myStruct.AccountsReceivableTaxType=getAccountsReceivableTaxType();
+                  myStruct["AccountsReceivableTaxType"]=getAccountsReceivableTaxType();
                 }
               }
             }
             if (structKeyExists(variables.instance,"AccountsPayableTaxType")) {
               if (NOT listFindNoCase(arguments.exclude, "AccountsPayableTaxType")) {
                 if (len(variables.instance.AccountsPayableTaxType) GT 0) {
-                  myStruct.AccountsPayableTaxType=getAccountsPayableTaxType();
+                  myStruct["AccountsPayableTaxType"]=getAccountsPayableTaxType();
                 }
               }
             }
             if (structKeyExists(variables.instance,"Addresses")) {
               if (NOT listFindNoCase(arguments.exclude, "Addresses")) {
                 if (ArrayLen(variables.instance.Addresses) GT 0) {
-                  myStruct.Addresses=getAddresses();
+                  myStruct["Addresses"]=getAddresses();
                 }
               }
             }
             if (structKeyExists(variables.instance,"Phones")) {
               if (NOT listFindNoCase(arguments.exclude, "Phones")) {
                 if (ArrayLen(variables.instance.Phones) GT 0) {
-                  myStruct.Phones=getPhones();
+                  myStruct["Phones"]=getPhones();
                 }
               }
             }
             if (structKeyExists(variables.instance,"IsSupplier")) {
               if (NOT listFindNoCase(arguments.exclude, "IsSupplier")) {
                 if (len(variables.instance.IsSupplier) GT 0) {
-                  myStruct.IsSupplier=getIsSupplier();
+                  myStruct["IsSupplier"]=getIsSupplier();
                 }
               }
             }
             if (structKeyExists(variables.instance,"IsCustomer")) {
               if (NOT listFindNoCase(arguments.exclude, "IsCustomer")) {
                 if (len(variables.instance.IsCustomer) GT 0) {
-                  myStruct.IsCustomer=getIsCustomer();
+                  myStruct["IsCustomer"]=getIsCustomer();
                 }
               }
             }
             if (structKeyExists(variables.instance,"DefaultCurrency")) {
               if (NOT listFindNoCase(arguments.exclude, "DefaultCurrency")) {
                 if (len(variables.instance.DefaultCurrency) GT 0) {
-                  myStruct.DefaultCurrency=getDefaultCurrency();
+                  myStruct["DefaultCurrency"]=getDefaultCurrency();
                 }
               }
             }
             if (structKeyExists(variables.instance,"XeroNetworkKey")) {
               if (NOT listFindNoCase(arguments.exclude, "XeroNetworkKey")) {
                 if (len(variables.instance.XeroNetworkKey) GT 0) {
-                  myStruct.XeroNetworkKey=getXeroNetworkKey();
+                  myStruct["XeroNetworkKey"]=getXeroNetworkKey();
                 }
               }
             }
             if (structKeyExists(variables.instance,"SalesDefaultAccountCode")) {
               if (NOT listFindNoCase(arguments.exclude, "SalesDefaultAccountCode")) {
                 if (len(variables.instance.SalesDefaultAccountCode) GT 0) {
-                  myStruct.SalesDefaultAccountCode=getSalesDefaultAccountCode();
+                  myStruct["SalesDefaultAccountCode"]=getSalesDefaultAccountCode();
                 }
               }
             }
             if (structKeyExists(variables.instance,"PurchasesDefaultAccountCode")) {
               if (NOT listFindNoCase(arguments.exclude, "PurchasesDefaultAccountCode")) {
                 if (len(variables.instance.PurchasesDefaultAccountCode) GT 0) {
-                  myStruct.PurchasesDefaultAccountCode=getPurchasesDefaultAccountCode();
+                  myStruct["PurchasesDefaultAccountCode"]=getPurchasesDefaultAccountCode();
                 }
               }
             }
             if (structKeyExists(variables.instance,"SalesTrackingCategories")) {
               if (NOT listFindNoCase(arguments.exclude, "SalesTrackingCategories")) {
                 if (ArrayLen(variables.instance.SalesTrackingCategories) GT 0) {
-                  myStruct.SalesTrackingCategories=getSalesTrackingCategories();
+                  myStruct["SalesTrackingCategories"]=getSalesTrackingCategories();
                 }
               }
             }
             if (structKeyExists(variables.instance,"PurchasesTrackingCategories")) {
               if (NOT listFindNoCase(arguments.exclude, "PurchasesTrackingCategories")) {
                 if (ArrayLen(variables.instance.PurchasesTrackingCategories) GT 0) {
-                  myStruct.PurchasesTrackingCategories=getPurchasesTrackingCategories();
+                  myStruct["PurchasesTrackingCategories"]=getPurchasesTrackingCategories();
                 }
               }
             }
             if (structKeyExists(variables.instance,"TrackingCategoryName")) {
               if (NOT listFindNoCase(arguments.exclude, "TrackingCategoryName")) {
                 if (len(variables.instance.TrackingCategoryName) GT 0) {
-                  myStruct.TrackingCategoryName=getTrackingCategoryName();
+                  myStruct["TrackingCategoryName"]=getTrackingCategoryName();
                 }
               }
             }
             if (structKeyExists(variables.instance,"TrackingCategoryOption")) {
               if (NOT listFindNoCase(arguments.exclude, "TrackingCategoryOption")) {
                 if (len(variables.instance.TrackingCategoryOption) GT 0) {
-                  myStruct.TrackingCategoryOption=getTrackingCategoryOption();
+                  myStruct["TrackingCategoryOption"]=getTrackingCategoryOption();
                 }
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
                 if (len(variables.instance.UpdatedDateUTC) GT 0) {
-                  myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                  myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
                 }
               }
             }
             if (structKeyExists(variables.instance,"ContactGroups")) {
               if (NOT listFindNoCase(arguments.exclude, "ContactGroups")) {
                 if (ArrayLen(variables.instance.ContactGroups) GT 0) {
-                  myStruct.ContactGroups=getContactGroups();
+                  myStruct["ContactGroups"]=getContactGroups();
                 }
               }
             }
             if (structKeyExists(variables.instance,"Website")) {
               if (NOT listFindNoCase(arguments.exclude, "Website")) {
                 if (len(variables.instance.Website) GT 0) {
-                  myStruct.Website=getWebsite();
+                  myStruct["Website"]=getWebsite();
                 }
               }
             }
             if (structKeyExists(variables.instance,"BatchPayments")) {
               if (NOT listFindNoCase(arguments.exclude, "BatchPayments")) {
                 if (len(variables.instance.BatchPayments) GT 0) {
-                  myStruct.BatchPayments=getBatchPayments();
+                  myStruct["BatchPayments"]=getBatchPayments();
                 }
               }
             }
             if (structKeyExists(variables.instance,"Discount")) {
               if (NOT listFindNoCase(arguments.exclude, "Discount")) {
                 if (len(variables.instance.Discount) GT 0) {
-                  myStruct.Discount=getDiscount();
+                  myStruct["Discount"]=getDiscount();
                 }
               }
             }
             if (structKeyExists(variables.instance,"Balances")) {
               if (NOT listFindNoCase(arguments.exclude, "Balances")) {
                 if (NOT structIsEmpty(variables.instance.Balances) GT 0) {
-                  myStruct.Balances=getBalances();
+                  myStruct["Balances"]=getBalances();
                 }
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
                 if (len(variables.instance.HasAttachments) GT 0) {
-                  myStruct.HasAttachments=getHasAttachments();
+                  myStruct["HasAttachments"]=getHasAttachments();
                 }
               }
             }
@@ -725,7 +726,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.ContactPersons);i=i+1) {
-		          var item=createObject("component","cfc.model.ContactPerson").init().populate(arguments.ContactPersons[i]); 
+		          var item=createObject("component","ContactPerson").init(variables.xero).populate(arguments.ContactPersons[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>
@@ -798,7 +799,7 @@
 			<cfscript>
         var arr = ArrayNew(1);
         for (var i=1;i LTE ArrayLen(arguments.Addresses);i=i+1) {
-          var item=createObject("component","cfc.model.Address").init().populate(arguments.Addresses[i]); 
+          var item=createObject("component","Address").init(variables.xero).populate(arguments.Addresses[i]); 
           ArrayAppend(arr,item);
         }
       </cfscript>
@@ -818,7 +819,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.Phones);i=i+1) {
-		          var item=createObject("component","cfc.model.Phone").init().populate(arguments.Phones[i]); 
+		          var item=createObject("component","Phone").init(variables.xero).populate(arguments.Phones[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>
@@ -982,7 +983,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.ContactGroups);i=i+1) {
-		          var item=createObject("component","cfc.model.ContactGroup").init().populate(arguments.ContactGroups[i]); 
+		          var item=createObject("component","ContactGroup").init(variables.xero).populate(arguments.ContactGroups[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>

--- a/model/ContactGroup.cfc
+++ b/model/ContactGroup.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="ContactGroup" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="ContactGroup" output="false" extends="xeroclient"
   hint="I am the ContactGroup Class.">
 
 <!--- PROPERTIES --->
@@ -11,7 +11,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the ContactGroup Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -53,28 +54,28 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.ContactGroupID=getContactGroupID();
-            myStruct.Status=getStatus();
+            myStruct["ContactGroupID"]=getContactGroupID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Name")) {
               if (NOT listFindNoCase(arguments.exclude, "Name")) {
-                myStruct.Name=getName();
+                myStruct["Name"]=getName();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"ContactGroupID")) {
               if (NOT listFindNoCase(arguments.exclude, "ContactGroupID")) {
-                myStruct.ContactGroupID=getContactGroupID();
+                myStruct["ContactGroupID"]=getContactGroupID();
               }
             }
             if (structKeyExists(variables.instance,"Contacts")) {
               if (NOT listFindNoCase(arguments.exclude, "Contacts")) {
-                myStruct.Contacts=getContacts();
+                myStruct["Contacts"]=getContacts();
               }
             }
           }
@@ -291,7 +292,7 @@
      <cfscript>
             var arr = ArrayNew(1);
             for (var i=1;i LTE ArrayLen(arguments.Contacts);i=i+1) {
-              var item=createObject("component","cfc.model.Contact").init().populate(arguments.Contacts[i]); 
+              var item=createObject("component","Contact").init().populate(arguments.Contacts[i]); 
               ArrayAppend(arr,item);
             }
       </cfscript>

--- a/model/ContactPerson.cfc
+++ b/model/ContactPerson.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="ContactPerson" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="ContactPerson" output="false" extends="xeroclient"
   hint="I am the ContactPerson Class.">
 
 <!--- PROPERTIES --->
@@ -10,7 +10,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the ContactPerson Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -47,28 +48,28 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.ContactPersonID=getContactPersonID();
-            myStruct.Status=getStatus();
+            myStruct["ContactPersonID"]=getContactPersonID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"FirstName")) {
               if (NOT listFindNoCase(arguments.exclude, "FirstName")) {
-                myStruct.FirstName=getFirstName();
+                myStruct["FirstName"]=getFirstName();
               }
             }
             if (structKeyExists(variables.instance,"LastName")) {
               if (NOT listFindNoCase(arguments.exclude, "LastName")) {
-                myStruct.LastName=getLastName();
+                myStruct["LastName"]=getLastName();
               }
             }
             if (structKeyExists(variables.instance,"EmailAddress")) {
               if (NOT listFindNoCase(arguments.exclude, "EmailAddress")) {
-                myStruct.EmailAddress=getEmailAddress();
+                myStruct["EmailAddress"]=getEmailAddress();
               }
             }
             if (structKeyExists(variables.instance,"IncludeInEmails")) {
               if (NOT listFindNoCase(arguments.exclude, "IncludeInEmails")) {
-                myStruct.IncludeInEmails=getIncludeInEmails();
+                myStruct["IncludeInEmails"]=getIncludeInEmails();
               }
             }
           }

--- a/model/CreditNote.cfc
+++ b/model/CreditNote.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="CreditNote" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="CreditNote" output="false" extends="xeroclient"
   hint="I am the CreditNote Class.">
 
 <!--- PROPERTIES --->
@@ -28,7 +28,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the CreditNote Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -72,115 +73,115 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.CreditNoteID=getCreditNoteID();
-            myStruct.Status=getStatus();
+            myStruct["CreditNoteID"]=getCreditNoteID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Type")) {
               if (NOT listFindNoCase(arguments.exclude, "Type")) {
-                myStruct.Type=getType();
+                myStruct["Type"]=getType();
               }
             }
             if (structKeyExists(variables.instance,"Contact")) {
               if (NOT listFindNoCase(arguments.exclude, "Contact")) {
-                myStruct.Contact=getContact();
+                myStruct["Contact"]=getContact();
               }
             }
             if (structKeyExists(variables.instance,"Date")) {
               if (NOT listFindNoCase(arguments.exclude, "Date")) {
-                myStruct.Date=getDate();
+                myStruct["Date"]=getDate();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"LineAmountTypes")) {
               if (NOT listFindNoCase(arguments.exclude, "LineAmountTypes")) {
-                myStruct.LineAmountTypes=getLineAmountTypes();
+                myStruct["LineAmountTypes"]=getLineAmountTypes();
               }
             }
             if (structKeyExists(variables.instance,"LineItems")) {
               if (NOT listFindNoCase(arguments.exclude, "LineItems")) {
-                myStruct.LineItems=getLineItems();
+                myStruct["LineItems"]=getLineItems();
               }
             }
             if (structKeyExists(variables.instance,"SubTotal")) {
               if (NOT listFindNoCase(arguments.exclude, "SubTotal")) {
-                myStruct.SubTotal=getSubTotal();
+                myStruct["SubTotal"]=getSubTotal();
               }
             }
             if (structKeyExists(variables.instance,"TotalTax")) {
               if (NOT listFindNoCase(arguments.exclude, "TotalTax")) {
-                myStruct.TotalTax=getTotalTax();
+                myStruct["TotalTax"]=getTotalTax();
               }
             }
             if (structKeyExists(variables.instance,"Total")) {
               if (NOT listFindNoCase(arguments.exclude, "Total")) {
-                myStruct.Total=getTotal();
+                myStruct["Total"]=getTotal();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyCode")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyCode")) {
-                myStruct.CurrencyCode=getCurrencyCode();
+                myStruct["CurrencyCode"]=getCurrencyCode();
               }
             }
             if (structKeyExists(variables.instance,"FullyPaidOnDate")) {
               if (NOT listFindNoCase(arguments.exclude, "FullyPaidOnDate")) {
-                myStruct.FullyPaidOnDate=getFullyPaidOnDate();
+                myStruct["FullyPaidOnDate"]=getFullyPaidOnDate();
               }
             }
             if (structKeyExists(variables.instance,"CreditNoteID")) {
               if (NOT listFindNoCase(arguments.exclude, "CreditNoteID")) {
-                myStruct.CreditNoteID=getCreditNoteID();
+                myStruct["CreditNoteID"]=getCreditNoteID();
               }
             }
             if (structKeyExists(variables.instance,"CreditNoteNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "CreditNoteNumber")) {
-                myStruct.CreditNoteNumber=getCreditNoteNumber();
+                myStruct["CreditNoteNumber"]=getCreditNoteNumber();
               }
             }
             if (structKeyExists(variables.instance,"Reference")) {
               if (NOT listFindNoCase(arguments.exclude, "Reference")) {
-                myStruct.Reference=getReference();
+                myStruct["Reference"]=getReference();
               }
             }
             if (structKeyExists(variables.instance,"SentToContact")) {
               if (NOT listFindNoCase(arguments.exclude, "SentToContact")) {
-                myStruct.SentToContact=getSentToContact();
+                myStruct["SentToContact"]=getSentToContact();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyRate")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyRate")) {
-                myStruct.CurrencyRate=getCurrencyRate();
+                myStruct["CurrencyRate"]=getCurrencyRate();
               }
             }
             if (structKeyExists(variables.instance,"RemainingCredit")) {
               if (NOT listFindNoCase(arguments.exclude, "RemainingCredit")) {
-                myStruct.RemainingCredit=getRemainingCredit();
+                myStruct["RemainingCredit"]=getRemainingCredit();
               }
             }
             if (structKeyExists(variables.instance,"Allocations")) {
               if (NOT listFindNoCase(arguments.exclude, "Allocations")) {
-                myStruct.Allocations=getAllocations();
+                myStruct["Allocations"]=getAllocations();
               }
             }
             if (structKeyExists(variables.instance,"BrandingThemeID")) {
               if (NOT listFindNoCase(arguments.exclude, "BrandingThemeID")) {
                 if(len(variables.instance.BrandingThemeID) GT 0) {
-                  myStruct.BrandingThemeID=getBrandingThemeID();
+                  myStruct["BrandingThemeID"]=getBrandingThemeID();
                 }
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
-                myStruct.HasAttachments=getHasAttachments();
+                myStruct["HasAttachments"]=getHasAttachments();
               }
             }
           }
@@ -474,7 +475,7 @@
 			<cfscript>
         var arr = ArrayNew(1);
         for (var i=1;i LTE ArrayLen(arguments.LineItems);i=i+1) {
-          var item=createObject("component","cfc.model.LineItem").init().populate(arguments.LineItems[i]); 
+          var item=createObject("component","LineItem").init(variables.xero).populate(arguments.LineItems[i]); 
           ArrayAppend(arr,item.toStruct());
         }
       </cfscript>
@@ -651,7 +652,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.Allocations);i=i+1) {
-		          var item=createObject("component","cfc.model.Allocation").init().populate(arguments.Allocations[i]); 
+		          var item=createObject("component","Allocation").init(variables.xero).populate(arguments.Allocations[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>

--- a/model/Currency.cfc
+++ b/model/Currency.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Currency" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Currency" output="false" extends="xeroclient"
   hint="I am the Currency Class.">
 
 <!--- PROPERTIES --->
@@ -9,7 +9,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Currency Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -46,18 +47,18 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.CurrencyID=getCurrencyID();
-            myStruct.Status=getStatus();
+            myStruct["CurrencyID"]=getCurrencyID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Code")) {
               if (NOT listFindNoCase(arguments.exclude, "Code")) {
-                myStruct.Code=getCode();
+                myStruct["Code"]=getCode();
               }
             }
             if (structKeyExists(variables.instance,"Description")) {
               if (NOT listFindNoCase(arguments.exclude, "Description")) {
-                myStruct.Description=getDescription();
+                myStruct["Description"]=getDescription();
               }
             }
           }

--- a/model/Employee.cfc
+++ b/model/Employee.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Employee" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Employee" output="false" extends="xeroclient"
   hint="I am the Employee Class.">
 
 <!--- PROPERTIES --->
@@ -12,7 +12,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Employee Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -56,34 +57,34 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.EmployeeID=getEmployeeID();
-            myStruct.Status=getStatus();
+            myStruct["EmployeeID"]=getEmployeeID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"EmployeeID")) {
               if (NOT listFindNoCase(arguments.exclude, "EmployeeID")) {
-                myStruct.EmployeeID=getEmployeeID();
+                myStruct["EmployeeID"]=getEmployeeID();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"FirstName")) {
               if (NOT listFindNoCase(arguments.exclude, "FirstName")) {
-                myStruct.FirstName=getFirstName();
+                myStruct["FirstName"]=getFirstName();
               }
             }
             if (structKeyExists(variables.instance,"LastName")) {
               if (NOT listFindNoCase(arguments.exclude, "LastName")) {
-                myStruct.LastName=getLastName();
+                myStruct["LastName"]=getLastName();
               }
             }
             if (structKeyExists(variables.instance,"ExternalLink")) {
               if (NOT listFindNoCase(arguments.exclude, "ExternalLink")) {
                 if (NOT structIsEmpty(getExternalLink())){
-                  myStruct.ExternalLink=getExternalLink();
+                  myStruct["ExternalLink"]=getExternalLink();
                 }
               }
             }

--- a/model/ExpenseClaim.cfc
+++ b/model/ExpenseClaim.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="ExpenseClaim" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="ExpenseClaim" output="false" extends="xeroclient"
   hint="I am the ExpenseClaim Class.">
 
 <!--- PROPERTIES --->
@@ -18,7 +18,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the ExpenseClaim Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -55,63 +56,63 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.ExpenseClaimID=getExpenseClaimID();
-            myStruct.Status=getStatus();
+            myStruct["ExpenseClaimID"]=getExpenseClaimID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Receipts")) {
               if (NOT listFindNoCase(arguments.exclude, "Receipts")) {
-                myStruct.Receipts=getReceipts();
+                myStruct["Receipts"]=getReceipts();
               }
             }
             if (structKeyExists(variables.instance,"ExpenseClaimID")) {
               if (NOT listFindNoCase(arguments.exclude, "ExpenseClaimID")) {
-                myStruct.ExpenseClaimID=getExpenseClaimID();
+                myStruct["ExpenseClaimID"]=getExpenseClaimID();
               }
             }
             if (structKeyExists(variables.instance,"Payments")) {
               if (NOT listFindNoCase(arguments.exclude, "Payments")) {
-                myStruct.Payments=getPayments();
+                myStruct["Payments"]=getPayments();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"Total")) {
               if (NOT listFindNoCase(arguments.exclude, "Total")) {
-                myStruct.Total=getTotal();
+                myStruct["Total"]=getTotal();
               }
             }
             if (structKeyExists(variables.instance,"AmountDue")) {
               if (NOT listFindNoCase(arguments.exclude, "AmountDue")) {
-                myStruct.AmountDue=getAmountDue();
+                myStruct["AmountDue"]=getAmountDue();
               }
             }
             if (structKeyExists(variables.instance,"AmountPaid")) {
               if (NOT listFindNoCase(arguments.exclude, "AmountPaid")) {
-                myStruct.AmountPaid=getAmountPaid();
+                myStruct["AmountPaid"]=getAmountPaid();
               }
             }
             if (structKeyExists(variables.instance,"PaymentDueDate")) {
               if (NOT listFindNoCase(arguments.exclude, "PaymentDueDate")) {
-                myStruct.PaymentDueDate=getPaymentDueDate();
+                myStruct["PaymentDueDate"]=getPaymentDueDate();
               }
             }
             if (structKeyExists(variables.instance,"ReportingDate")) {
               if (NOT listFindNoCase(arguments.exclude, "ReportingDate")) {
-                myStruct.ReportingDate=getReportingDate();
+                myStruct["ReportingDate"]=getReportingDate();
               }
             }
             if (structKeyExists(variables.instance,"ReceiptID")) {
               if (NOT listFindNoCase(arguments.exclude, "ReceiptID")) {
-                myStruct.ReceiptID=getReceiptID();
+                myStruct["ReceiptID"]=getReceiptID();
               }
             }
           }

--- a/model/ExternalLink.cfc
+++ b/model/ExternalLink.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="ExternalLink" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="ExternalLink" output="false" extends="xeroclient"
   hint="I am the ExternalLink Class.">
 
 <!--- PROPERTIES --->
@@ -9,7 +9,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the ExternalLink Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -46,18 +47,18 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.ExternalLinkID=getExternalLinkID();
-            myStruct.Status=getStatus();
+            myStruct["ExternalLinkID"]=getExternalLinkID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"LinkType")) {
               if (NOT listFindNoCase(arguments.exclude, "LinkType")) {
-                myStruct.LinkType=getLinkType();
+                myStruct["LinkType"]=getLinkType();
               }
             }
             if (structKeyExists(variables.instance,"Url")) {
               if (NOT listFindNoCase(arguments.exclude, "Url")) {
-                myStruct.Url=getUrl();
+                myStruct["Url"]=getUrl();
               }
             }
           }

--- a/model/Invoice.cfc
+++ b/model/Invoice.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Invoice" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Invoice" output="false" extends="xeroclient"
   hint="I am the Invoice Class.">
 
 <!--- PROPERTIES --->
@@ -38,7 +38,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Invoice Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -88,167 +89,167 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.InvoiceID=getInvoiceID();
-            myStruct.Status=getStatus();
+            myStruct["InvoiceID"]=getInvoiceID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Type")) {
               if (NOT listFindNoCase(arguments.exclude, "Type")) {
-                myStruct.Type=getType();
+                myStruct["Type"]=getType();
               }
             }
             if (structKeyExists(variables.instance,"Contact")) {
               if (NOT listFindNoCase(arguments.exclude, "Contact")) {
-                myStruct.Contact=getContact();
+                myStruct["Contact"]=getContact();
               }
             }
             if (structKeyExists(variables.instance,"LineItems")) {
               if (NOT listFindNoCase(arguments.exclude, "LineItems")) {
-                myStruct.LineItems=getLineItems();
+                myStruct["LineItems"]=getLineItems();
               }
             }
             if (structKeyExists(variables.instance,"Date")) {
               if (NOT listFindNoCase(arguments.exclude, "Date")) {
-                myStruct.Date=getDate();
+                myStruct["Date"]=getDate();
               }
             }
             if (structKeyExists(variables.instance,"DueDate")) {
               if (NOT listFindNoCase(arguments.exclude, "DueDate")) {
-                myStruct.DueDate=getDueDate();
+                myStruct["DueDate"]=getDueDate();
               }
             }
             if (structKeyExists(variables.instance,"LineAmountTypes")) {
               if (NOT listFindNoCase(arguments.exclude, "LineAmountTypes")) {
-                myStruct.LineAmountTypes=getLineAmountTypes();
+                myStruct["LineAmountTypes"]=getLineAmountTypes();
               }
             }
             if (structKeyExists(variables.instance,"InvoiceNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "InvoiceNumber")) {
-                myStruct.InvoiceNumber=getInvoiceNumber();
+                myStruct["InvoiceNumber"]=getInvoiceNumber();
               }
             }
             if (structKeyExists(variables.instance,"Reference")) {
               if (NOT listFindNoCase(arguments.exclude, "Reference")) {
-                myStruct.Reference=getReference();
+                myStruct["Reference"]=getReference();
               }
             }
             if (structKeyExists(variables.instance,"BrandingThemeID")) {
               if (NOT listFindNoCase(arguments.exclude, "BrandingThemeID")) {
                 if(len(variables.instance.BrandingThemeID) GT 0) {
-                  myStruct.BrandingThemeID=getBrandingThemeID();
+                  myStruct["BrandingThemeID"]=getBrandingThemeID();
                 }
               }
             }
             if (structKeyExists(variables.instance,"Url")) {
               if (NOT listFindNoCase(arguments.exclude, "Url")) {
                  if(len(variables.instance.Url) GT 0) {
-                   myStruct.Url=getUrl();
+                   myStruct["Url"]=getUrl();
                 }
               }
             }
             if (structKeyExists(variables.instance,"CurrencyCode")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyCode")) {
-                myStruct.CurrencyCode=getCurrencyCode();
+                myStruct["CurrencyCode"]=getCurrencyCode();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyRate")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyRate")) {
-                myStruct.CurrencyRate=getCurrencyRate();
+                myStruct["CurrencyRate"]=getCurrencyRate();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"SentToContact")) {
               if (NOT listFindNoCase(arguments.exclude, "SentToContact")) {
-                myStruct.SentToContact=getSentToContact();
+                myStruct["SentToContact"]=getSentToContact();
               }
             }
             if (structKeyExists(variables.instance,"ExpectedPaymentDate")) {
               if (NOT listFindNoCase(arguments.exclude, "ExpectedPaymentDate")) {
-                myStruct.ExpectedPaymentDate=getExpectedPaymentDate();
+                myStruct["ExpectedPaymentDate"]=getExpectedPaymentDate();
               }
             }
             if (structKeyExists(variables.instance,"PlannedPaymentDate")) {
               if (NOT listFindNoCase(arguments.exclude, "PlannedPaymentDate")) {
-                myStruct.PlannedPaymentDate=getPlannedPaymentDate();
+                myStruct["PlannedPaymentDate"]=getPlannedPaymentDate();
               }
             }
             if (structKeyExists(variables.instance,"SubTotal")) {
               if (NOT listFindNoCase(arguments.exclude, "SubTotal")) {
-                myStruct.SubTotal=getSubTotal();
+                myStruct["SubTotal"]=getSubTotal();
               }
             }
             if (structKeyExists(variables.instance,"TotalTax")) {
               if (NOT listFindNoCase(arguments.exclude, "TotalTax")) {
-                myStruct.TotalTax=getTotalTax();
+                myStruct["TotalTax"]=getTotalTax();
               }
             }
             if (structKeyExists(variables.instance,"Total")) {
               if (NOT listFindNoCase(arguments.exclude, "Total")) {
-                myStruct.Total=getTotal();
+                myStruct["Total"]=getTotal();
               }
             }
             if (structKeyExists(variables.instance,"TotalDiscount")) {
               if (NOT listFindNoCase(arguments.exclude, "TotalDiscount")) {
-                myStruct.TotalDiscount=getTotalDiscount();
+                myStruct["TotalDiscount"]=getTotalDiscount();
               }
             }
             if (structKeyExists(variables.instance,"InvoiceID")) {
               if (NOT listFindNoCase(arguments.exclude, "InvoiceID")) {
-                myStruct.InvoiceID=getInvoiceID();
+                myStruct["InvoiceID"]=getInvoiceID();
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
-                myStruct.HasAttachments=getHasAttachments();
+                myStruct["HasAttachments"]=getHasAttachments();
               }
             }
             if (structKeyExists(variables.instance,"Payments")) {
               if (NOT listFindNoCase(arguments.exclude, "Payments")) {
-                myStruct.Payments=getPayments();
+                myStruct["Payments"]=getPayments();
               }
             }
             if (structKeyExists(variables.instance,"Prepayments")) {
               if (NOT listFindNoCase(arguments.exclude, "Prepayments")) {
-                myStruct.Prepayments=getPrepayments();
+                myStruct["Prepayments"]=getPrepayments();
               }
             }
             if (structKeyExists(variables.instance,"Overpayments")) {
               if (NOT listFindNoCase(arguments.exclude, "Overpayments")) {
-                myStruct.Overpayments=getOverpayments();
+                myStruct["Overpayments"]=getOverpayments();
               }
             }
             if (structKeyExists(variables.instance,"AmountDue")) {
               if (NOT listFindNoCase(arguments.exclude, "AmountDue")) {
-                myStruct.AmountDue=getAmountDue();
+                myStruct["AmountDue"]=getAmountDue();
               }
             }
             if (structKeyExists(variables.instance,"AmountPaid")) {
               if (NOT listFindNoCase(arguments.exclude, "AmountPaid")) {
-                myStruct.AmountPaid=getAmountPaid();
+                myStruct["AmountPaid"]=getAmountPaid();
               }
             }
             if (structKeyExists(variables.instance,"FullyPaidOnDate")) {
               if (NOT listFindNoCase(arguments.exclude, "FullyPaidOnDate")) {
-                myStruct.FullyPaidOnDate=getFullyPaidOnDate();
+                myStruct["FullyPaidOnDate"]=getFullyPaidOnDate();
               }
             }
             if (structKeyExists(variables.instance,"AmountCredited")) {
               if (NOT listFindNoCase(arguments.exclude, "AmountCredited")) {
-                myStruct.AmountCredited=getAmountCredited();
+                myStruct["AmountCredited"]=getAmountCredited();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"CreditNotes")) {
               if (NOT listFindNoCase(arguments.exclude, "CreditNotes")) {
-                myStruct.CreditNotes=getCreditNotes();
+                myStruct["CreditNotes"]=getCreditNotes();
               }
             }
           }
@@ -565,7 +566,7 @@
 		   <cfscript>
             var arr = ArrayNew(1);
             for (var i=1;i LTE ArrayLen(arguments.Lineitems);i=i+1) {
-              var item=createObject("component","cfc.model.Lineitem").init().populate(arguments.Lineitems[i]); 
+              var item=createObject("component","LineItem").init(variables.xero).populate(arguments.Lineitems[i]); 
               ArrayAppend(arr,item);
             }
       </cfscript>
@@ -833,7 +834,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.Payments);i=i+1) {
-		          var item=createObject("component","cfc.model.Payment").init().populate(arguments.Payments[i]); 
+		          var item=createObject("component","Payment").init(variables.xero).populate(arguments.Payments[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>
@@ -854,7 +855,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.Prepayments);i=i+1) {
-		          var item=createObject("component","cfc.model.Prepayment").init().populate(arguments.Prepayments[i]); 
+		          var item=createObject("component","Prepayment").init(variables.xero).populate(arguments.Prepayments[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>
@@ -875,7 +876,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.Overpayments);i=i+1) {
-		          var item=createObject("component","cfc.model.Overpayment").init().populate(arguments.Overpayments[i]); 
+		          var item=createObject("component","Overpayment").init(variables.xero).populate(arguments.Overpayments[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>
@@ -961,7 +962,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.CreditNotes);i=i+1) {
-		          var item=createObject("component","cfc.model.CreditNote").init().populate(arguments.CreditNotes[i]); 
+		          var item=createObject("component","CreditNote").init(variables.xero).populate(arguments.CreditNotes[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>

--- a/model/InvoiceReminder.cfc
+++ b/model/InvoiceReminder.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="InvoiceReminder" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="InvoiceReminder" output="false" extends="xeroclient"
   hint="I am the InvoiceReminder Class.">
 
 <!--- PROPERTIES --->
@@ -8,7 +8,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the InvoiceReminder Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -46,7 +47,7 @@
           myStruct=StructNew();
           if (structKeyExists(variables.instance,"Enabled")) {
             if (NOT listFindNoCase(arguments.exclude, "Enabled")) {
-              myStruct.Enabled=getEnabled();
+              myStruct["Enabled"]=getEnabled();
             }
           }
         </cfscript>

--- a/model/Item.cfc
+++ b/model/Item.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Item" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Item" output="false" extends="xeroclient"
   hint="I am the Item Class.">
 
 <!--- PROPERTIES --->
@@ -21,7 +21,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Item Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -58,78 +59,78 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.ItemID=getItemID();
-            myStruct.Status=getStatus();
+            myStruct["ItemID"]=getItemID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Code")) {
               if (NOT listFindNoCase(arguments.exclude, "Code")) {
-                myStruct.Code=getCode();
+                myStruct["Code"]=getCode();
               }
             }
             if (structKeyExists(variables.instance,"InventoryAssetAccountCode")) {
               if (NOT listFindNoCase(arguments.exclude, "InventoryAssetAccountCode")) {
-                myStruct.InventoryAssetAccountCode=getInventoryAssetAccountCode();
+                myStruct["InventoryAssetAccountCode"]=getInventoryAssetAccountCode();
               }
             }
             if (structKeyExists(variables.instance,"Name")) {
               if (NOT listFindNoCase(arguments.exclude, "Name")) {
-                myStruct.Name=getName();
+                myStruct["Name"]=getName();
               }
             }
             if (structKeyExists(variables.instance,"IsSold")) {
               if (NOT listFindNoCase(arguments.exclude, "IsSold")) {
-                myStruct.IsSold=getIsSold();
+                myStruct["IsSold"]=getIsSold();
               }
             }
             if (structKeyExists(variables.instance,"IsPurchased")) {
               if (NOT listFindNoCase(arguments.exclude, "IsPurchased")) {
-                myStruct.IsPurchased=getIsPurchased();
+                myStruct["IsPurchased"]=getIsPurchased();
               }
             }
             if (structKeyExists(variables.instance,"Description")) {
               if (NOT listFindNoCase(arguments.exclude, "Description")) {
-                myStruct.Description=getDescription();
+                myStruct["Description"]=getDescription();
               }
             }
             if (structKeyExists(variables.instance,"PurchaseDescription")) {
               if (NOT listFindNoCase(arguments.exclude, "PurchaseDescription")) {
-                myStruct.PurchaseDescription=getPurchaseDescription();
+                myStruct["PurchaseDescription"]=getPurchaseDescription();
               }
             }
             if (structKeyExists(variables.instance,"PurchaseDetails")) {
               if (NOT listFindNoCase(arguments.exclude, "PurchaseDetails")) {
-                myStruct.PurchaseDetails=getPurchaseDetails();
+                myStruct["PurchaseDetails"]=getPurchaseDetails();
               }
             }
             if (structKeyExists(variables.instance,"SalesDetails")) {
               if (NOT listFindNoCase(arguments.exclude, "SalesDetails")) {
-                myStruct.SalesDetails=getSalesDetails();
+                myStruct["SalesDetails"]=getSalesDetails();
               }
             }
             if (structKeyExists(variables.instance,"IsTrackedAsInventory")) {
               if (NOT listFindNoCase(arguments.exclude, "IsTrackedAsInventory")) {
-                myStruct.IsTrackedAsInventory=getIsTrackedAsInventory();
+                myStruct["IsTrackedAsInventory"]=getIsTrackedAsInventory();
               }
             }
             if (structKeyExists(variables.instance,"TotalCostPool")) {
               if (NOT listFindNoCase(arguments.exclude, "TotalCostPool")) {
-                myStruct.TotalCostPool=getTotalCostPool();
+                myStruct["TotalCostPool"]=getTotalCostPool();
               }
             }
             if (structKeyExists(variables.instance,"QuantityOnHand")) {
               if (NOT listFindNoCase(arguments.exclude, "QuantityOnHand")) {
-                myStruct.QuantityOnHand=getQuantityOnHand();
+                myStruct["QuantityOnHand"]=getQuantityOnHand();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"ItemID")) {
               if (NOT listFindNoCase(arguments.exclude, "ItemID")) {
-                myStruct.ItemID=getItemID();
+                myStruct["ItemID"]=getItemID();
               }
             }
           }

--- a/model/Journal.cfc
+++ b/model/Journal.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Journal" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Journal" output="false" extends="xeroclient"
   hint="I am the Journal Class.">
 
 <!--- PROPERTIES --->
@@ -15,7 +15,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Journal Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -45,42 +46,42 @@
 
           if (structKeyExists(variables.instance,"JournalID")) {
             if (NOT listFindNoCase(arguments.exclude, "JournalID")) {
-              myStruct.JournalID=getJournalID();
+              myStruct["JournalID"]=getJournalID();
             }
           }
           if (structKeyExists(variables.instance,"JournalDate")) {
             if (NOT listFindNoCase(arguments.exclude, "JournalDate")) {
-              myStruct.JournalDate=getJournalDate();
+              myStruct["JournalDate"]=getJournalDate();
             }
           }
           if (structKeyExists(variables.instance,"JournalNumber")) {
             if (NOT listFindNoCase(arguments.exclude, "JournalNumber")) {
-              myStruct.JournalNumber=getJournalNumber();
+              myStruct["JournalNumber"]=getJournalNumber();
             }
           }
           if (structKeyExists(variables.instance,"CreatedDateUTC")) {
             if (NOT listFindNoCase(arguments.exclude, "CreatedDateUTC")) {
-              myStruct.CreatedDateUTC=getCreatedDateUTC();
+              myStruct["CreatedDateUTC"]=getCreatedDateUTC();
             }
           }
           if (structKeyExists(variables.instance,"Reference")) {
             if (NOT listFindNoCase(arguments.exclude, "Reference")) {
-              myStruct.Reference=getReference();
+              myStruct["Reference"]=getReference();
             }
           }
           if (structKeyExists(variables.instance,"SourceID")) {
             if (NOT listFindNoCase(arguments.exclude, "SourceID")) {
-              myStruct.SourceID=getSourceID();
+              myStruct["SourceID"]=getSourceID();
             }
           }
           if (structKeyExists(variables.instance,"SourceType")) {
             if (NOT listFindNoCase(arguments.exclude, "SourceType")) {
-              myStruct.SourceType=getSourceType();
+              myStruct["SourceType"]=getSourceType();
             }
           }
           if (structKeyExists(variables.instance,"JournalLines")) {
             if (NOT listFindNoCase(arguments.exclude, "JournalLines")) {
-              myStruct.JournalLines=getJournalLines();
+              myStruct["JournalLines"]=getJournalLines();
             }
           }
         </cfscript>
@@ -330,7 +331,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.JournalLines);i=i+1) {
-		          var item=createObject("component","cfc.model.JournalLine").init().populate(arguments.JournalLines[i]); 
+		          var item=createObject("component","JournalLine").init(variables.xero).populate(arguments.JournalLines[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>

--- a/model/JournalLine.cfc
+++ b/model/JournalLine.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="JournalLine" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="JournalLine" output="false" extends="xeroclient"
   hint="I am the JournalLine Class.">
 
 <!--- PROPERTIES --->
@@ -13,7 +13,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the JournalLine Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -57,40 +58,40 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.JournalLineID=getJournalLineID();
-            myStruct.Status=getStatus();
+            myStruct["JournalLineID"]=getJournalLineID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"LineAmount")) {
               if (NOT listFindNoCase(arguments.exclude, "LineAmount")) {
-                myStruct.LineAmount=getLineAmount();
+                myStruct["LineAmount"]=getLineAmount();
               }
             }
             if (structKeyExists(variables.instance,"AccountCode")) {
               if (NOT listFindNoCase(arguments.exclude, "AccountCode")) {
-                myStruct.AccountCode=getAccountCode();
+                myStruct["AccountCode"]=getAccountCode();
               }
             }
             if (structKeyExists(variables.instance,"Description")) {
               if (NOT listFindNoCase(arguments.exclude, "Description")) {
                 if(len(getDescription()) GT 0) {
-                  myStruct.Description=getDescription();
+                  myStruct["Description"]=getDescription();
                 }
               }
             }
             if (structKeyExists(variables.instance,"TaxType")) {
               if (NOT listFindNoCase(arguments.exclude, "TaxType")) {
-                myStruct.TaxType=getTaxType();
+                myStruct["TaxType"]=getTaxType();
               }
             }
             if (structKeyExists(variables.instance,"Tracking")) {
               if (NOT listFindNoCase(arguments.exclude, "Tracking")) {
-                myStruct.Tracking=getTracking();
+                myStruct["Tracking"]=getTracking();
               }
             }
             if (structKeyExists(variables.instance,"TaxAmount")) {
               if (NOT listFindNoCase(arguments.exclude, "TaxAmount")) {
-                myStruct.TaxAmount=getTaxAmount();
+                myStruct["TaxAmount"]=getTaxAmount();
               }
             }
           }

--- a/model/LineItem.cfc
+++ b/model/LineItem.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="LineItem" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="LineItem" output="false" extends="xeroclient"
   hint="I am the LineItem Class.">
 
 <!--- PROPERTIES --->
@@ -19,7 +19,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the LineItem Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -70,64 +71,64 @@
 
           if (structKeyExists(variables.instance,"Description")) {
             if (NOT listFindNoCase(arguments.exclude, "Description")) {
-              myStruct.Description=getDescription();
+              myStruct["Description"]=getDescription();
             }
           }
           if (structKeyExists(variables.instance,"Quantity")) {
             if (NOT listFindNoCase(arguments.exclude, "Quantity")) {
-              myStruct.Quantity=getQuantity();
+              myStruct["Quantity"]=getQuantity();
             }
           }
           if (structKeyExists(variables.instance,"UnitAmount")) {
             if (NOT listFindNoCase(arguments.exclude, "UnitAmount")) {
-              myStruct.UnitAmount=getUnitAmount();
+              myStruct["UnitAmount"]=getUnitAmount();
             }
           }
           if (structKeyExists(variables.instance,"ItemCode")) {
             if (NOT listFindNoCase(arguments.exclude, "ItemCode")) {
               if(len(variables.instance.ItemCode) GT 0){
-                myStruct.ItemCode=getItemCode();
+                myStruct["ItemCode"]=getItemCode();
               }
             }
           }
           if (structKeyExists(variables.instance,"AccountCode")) {
             if (NOT listFindNoCase(arguments.exclude, "AccountCode")) {
-              myStruct.AccountCode=getAccountCode();
+              myStruct["AccountCode"]=getAccountCode();
             }
           }
           if (structKeyExists(variables.instance,"TaxType")) {
             if (NOT listFindNoCase(arguments.exclude, "TaxType")) {
-              myStruct.TaxType=getTaxType();
+              myStruct["TaxType"]=getTaxType();
             }
           }
           if (structKeyExists(variables.instance,"TaxAmount")) {
             if (NOT listFindNoCase(arguments.exclude, "TaxAmount")) {
-              myStruct.TaxAmount=getTaxAmount();
+              myStruct["TaxAmount"]=getTaxAmount();
             }
           }
           if (structKeyExists(variables.instance,"LineAmount")) {
             if (NOT listFindNoCase(arguments.exclude, "LineAmount")) {
-              myStruct.LineAmount=getLineAmount();
+              myStruct["LineAmount"]=getLineAmount();
             }
           }
           if (structKeyExists(variables.instance,"Tracking")) {
             if (NOT listFindNoCase(arguments.exclude, "Tracking")) {
-              myStruct.Tracking=getTracking();
+              myStruct["Tracking"]=getTracking();
             }
           }
           if (structKeyExists(variables.instance,"DiscountRate")) {
             if (NOT listFindNoCase(arguments.exclude, "DiscountRate")) {
-              myStruct.DiscountRate=getDiscountRate();
+              myStruct["DiscountRate"]=getDiscountRate();
             }
           }
           if (structKeyExists(variables.instance,"RepeatingInvoiceID")) {
             if (NOT listFindNoCase(arguments.exclude, "RepeatingInvoiceID")) {
-              myStruct.RepeatingInvoiceID=getRepeatingInvoiceID();
+              myStruct["RepeatingInvoiceID"]=getRepeatingInvoiceID();
             }
           }
          if (structKeyExists(variables.instance,"LineItemID")) {
             if (NOT listFindNoCase(arguments.exclude, "LineItemID")) {
-              myStruct.LineItemID=getLineItemID();
+              myStruct["LineItemID"]=getLineItemID();
             }
           }
         </cfscript>

--- a/model/LinkedTransaction.cfc
+++ b/model/LinkedTransaction.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="LinkedTransaction" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="LinkedTransaction" output="false" extends="xeroclient"
   hint="I am the LinkedTransaction Class.">
 
 <!--- PROPERTIES --->
@@ -17,7 +17,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the LinkedTransaction Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -61,58 +62,58 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.LinkedTransactionID=getLinkedTransactionID();
-            myStruct.Status=getStatus();
+            myStruct["LinkedTransactionID"]=getLinkedTransactionID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"SourceTransactionID")) {
               if (NOT listFindNoCase(arguments.exclude, "SourceTransactionID")) {
-                myStruct.SourceTransactionID=getSourceTransactionID();
+                myStruct["SourceTransactionID"]=getSourceTransactionID();
               }
             }
             if (structKeyExists(variables.instance,"SourceLineItemID")) {
               if (NOT listFindNoCase(arguments.exclude, "SourceLineItemID")) {
-                myStruct.SourceLineItemID=getSourceLineItemID();
+                myStruct["SourceLineItemID"]=getSourceLineItemID();
               }
             }
             if (structKeyExists(variables.instance,"ContactID")) {
               if (NOT listFindNoCase(arguments.exclude, "ContactID")) {
-                myStruct.ContactID=getContactID();
+                myStruct["ContactID"]=getContactID();
               }
             }
             if (structKeyExists(variables.instance,"TargetTransactionID")) {
               if (NOT listFindNoCase(arguments.exclude, "TargetTransactionID")) {
-                myStruct.TargetTransactionID=getTargetTransactionID();
+                myStruct["TargetTransactionID"]=getTargetTransactionID();
               }
             }
             if (structKeyExists(variables.instance,"TargetLineItemID")) {
               if (NOT listFindNoCase(arguments.exclude, "TargetLineItemID")) {
-                myStruct.TargetLineItemID=getTargetLineItemID();
+                myStruct["TargetLineItemID"]=getTargetLineItemID();
               }
             }
             if (structKeyExists(variables.instance,"LinkedTransactionID")) {
               if (NOT listFindNoCase(arguments.exclude, "LinkedTransactionID")) {
-                myStruct.LinkedTransactionID=getLinkedTransactionID();
+                myStruct["LinkedTransactionID"]=getLinkedTransactionID();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"Type")) {
               if (NOT listFindNoCase(arguments.exclude, "Type")) {
-                myStruct.Type=getType();
+                myStruct["Type"]=getType();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"SourceTransactionTypeCode")) {
               if (NOT listFindNoCase(arguments.exclude, "SourceTransactionTypeCode")) {
-                myStruct.SourceTransactionTypeCode=getSourceTransactionTypeCode();
+                myStruct["SourceTransactionTypeCode"]=getSourceTransactionTypeCode();
               }
             }
           }

--- a/model/ManualJournal.cfc
+++ b/model/ManualJournal.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="ManualJournal" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="ManualJournal" output="false" extends="xeroclient"
   hint="I am the ManualJournal Class.">
 
 <!--- PROPERTIES --->
@@ -17,7 +17,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the ManualJournal Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -61,55 +62,55 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.ManualJournalID=getManualJournalID();
-            myStruct.Status=getStatus();
+            myStruct["ManualJournalID"]=getManualJournalID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Narration")) {
               if (NOT listFindNoCase(arguments.exclude, "Narration")) {
-                myStruct.Narration=getNarration();
+                myStruct["Narration"]=getNarration();
               }
             }
             if (structKeyExists(variables.instance,"JournalLines")) {
               if (NOT listFindNoCase(arguments.exclude, "JournalLines")) {
-                myStruct.JournalLines=getJournalLines();
+                myStruct["JournalLines"]=getJournalLines();
               }
             }
             if (structKeyExists(variables.instance,"Date")) {
               if (NOT listFindNoCase(arguments.exclude, "Date")) {
-                myStruct.Date=getDate();
+                myStruct["Date"]=getDate();
               }
             }
             if (structKeyExists(variables.instance,"LineAmountTypes")) {
               if (NOT listFindNoCase(arguments.exclude, "LineAmountTypes")) {
-                myStruct.LineAmountTypes=getLineAmountTypes();
+                myStruct["LineAmountTypes"]=getLineAmountTypes();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"Url")) {
               if (NOT listFindNoCase(arguments.exclude, "Url")) {
                 if(len(getUrl()) GT 0) {
-                  myStruct.Url=getUrl();
+                  myStruct["Url"]=getUrl();
                 }
               }
             }
             if (structKeyExists(variables.instance,"ShowOnCashBasisReports")) {
               if (NOT listFindNoCase(arguments.exclude, "ShowOnCashBasisReports")) {
-                myStruct.ShowOnCashBasisReports=getShowOnCashBasisReports();
+                myStruct["ShowOnCashBasisReports"]=getShowOnCashBasisReports();
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
-                myStruct.HasAttachments=getHasAttachments();
+                myStruct["HasAttachments"]=getHasAttachments();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
           }
@@ -306,7 +307,7 @@
       <cfscript>
             var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.JournalLines);i=i+1) {
-		          var item=createObject("component","cfc.model.JournalLine").init().populate(arguments.JournalLines[i]); 
+		          var item=createObject("component","JournalLine").init(variables.xero).populate(arguments.JournalLines[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		  </cfscript>

--- a/model/Organisation.cfc
+++ b/model/Organisation.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Organisation" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Organisation" output="false" extends="xeroclient"
   hint="I am the Organisation Class.">
 
 <!--- PROPERTIES --->
@@ -36,7 +36,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Organisation Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -80,153 +81,153 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.OrganisationID=getOrganisationID();
-            myStruct.Status=getStatus();
+            myStruct["OrganisationID"]=getOrganisationID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"APIKey")) {
               if (NOT listFindNoCase(arguments.exclude, "APIKey")) {
-                myStruct.APIKey=getAPIKey();
+                myStruct["APIKey"]=getAPIKey();
               }
             }
             if (structKeyExists(variables.instance,"Name")) {
               if (NOT listFindNoCase(arguments.exclude, "Name")) {
-                myStruct.Name=getName();
+                myStruct["Name"]=getName();
               }
             }
             if (structKeyExists(variables.instance,"LegalName")) {
               if (NOT listFindNoCase(arguments.exclude, "LegalName")) {
-                myStruct.LegalName=getLegalName();
+                myStruct["LegalName"]=getLegalName();
               }
             }
             if (structKeyExists(variables.instance,"PaysTax")) {
               if (NOT listFindNoCase(arguments.exclude, "PaysTax")) {
-                myStruct.PaysTax=getPaysTax();
+                myStruct["PaysTax"]=getPaysTax();
               }
             }
             if (structKeyExists(variables.instance,"Version")) {
               if (NOT listFindNoCase(arguments.exclude, "Version")) {
-                myStruct.Version=getVersion();
+                myStruct["Version"]=getVersion();
               }
             }
             if (structKeyExists(variables.instance,"OrganisationType")) {
               if (NOT listFindNoCase(arguments.exclude, "OrganisationType")) {
-                myStruct.OrganisationType=getOrganisationType();
+                myStruct["OrganisationType"]=getOrganisationType();
               }
             }
             if (structKeyExists(variables.instance,"BaseCurrency")) {
               if (NOT listFindNoCase(arguments.exclude, "BaseCurrency")) {
-                myStruct.BaseCurrency=getBaseCurrency();
+                myStruct["BaseCurrency"]=getBaseCurrency();
               }
             }
             if (structKeyExists(variables.instance,"CountryCode")) {
               if (NOT listFindNoCase(arguments.exclude, "CountryCode")) {
-                myStruct.CountryCode=getCountryCode();
+                myStruct["CountryCode"]=getCountryCode();
               }
             }
             if (structKeyExists(variables.instance,"IsDemoCompany")) {
               if (NOT listFindNoCase(arguments.exclude, "IsDemoCompany")) {
-                myStruct.IsDemoCompany=getIsDemoCompany();
+                myStruct["IsDemoCompany"]=getIsDemoCompany();
               }
             }
             if (structKeyExists(variables.instance,"OrganisationStatus")) {
               if (NOT listFindNoCase(arguments.exclude, "OrganisationStatus")) {
-                myStruct.OrganisationStatus=getOrganisationStatus();
+                myStruct["OrganisationStatus"]=getOrganisationStatus();
               }
             }
             if (structKeyExists(variables.instance,"RegistrationNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "RegistrationNumber")) {
-                myStruct.RegistrationNumber=getRegistrationNumber();
+                myStruct["RegistrationNumber"]=getRegistrationNumber();
               }
             }
             if (structKeyExists(variables.instance,"TaxNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "TaxNumber")) {
-                myStruct.TaxNumber=getTaxNumber();
+                myStruct["TaxNumber"]=getTaxNumber();
               }
             }
             if (structKeyExists(variables.instance,"FinancialYearEndDay")) {
               if (NOT listFindNoCase(arguments.exclude, "FinancialYearEndDay")) {
-                myStruct.FinancialYearEndDay=getFinancialYearEndDay();
+                myStruct["FinancialYearEndDay"]=getFinancialYearEndDay();
               }
             }
             if (structKeyExists(variables.instance,"FinancialYearEndMonth")) {
               if (NOT listFindNoCase(arguments.exclude, "FinancialYearEndMonth")) {
-                myStruct.FinancialYearEndMonth=getFinancialYearEndMonth();
+                myStruct["FinancialYearEndMonth"]=getFinancialYearEndMonth();
               }
             }
             if (structKeyExists(variables.instance,"SalesTaxBasis")) {
               if (NOT listFindNoCase(arguments.exclude, "SalesTaxBasis")) {
-                myStruct.SalesTaxBasis=getSalesTaxBasis();
+                myStruct["SalesTaxBasis"]=getSalesTaxBasis();
               }
             }
             if (structKeyExists(variables.instance,"SalesTaxPeriod")) {
               if (NOT listFindNoCase(arguments.exclude, "SalesTaxPeriod")) {
-                myStruct.SalesTaxPeriod=getSalesTaxPeriod();
+                myStruct["SalesTaxPeriod"]=getSalesTaxPeriod();
               }
             }
             if (structKeyExists(variables.instance,"DefaultSalesTax")) {
               if (NOT listFindNoCase(arguments.exclude, "DefaultSalesTax")) {
-                myStruct.DefaultSalesTax=getDefaultSalesTax();
+                myStruct["DefaultSalesTax"]=getDefaultSalesTax();
               }
             }
             if (structKeyExists(variables.instance,"DefaultPurchasesTax")) {
               if (NOT listFindNoCase(arguments.exclude, "DefaultPurchasesTax")) {
-                myStruct.DefaultPurchasesTax=getDefaultPurchasesTax();
+                myStruct["DefaultPurchasesTax"]=getDefaultPurchasesTax();
               }
             }
             if (structKeyExists(variables.instance,"PeriodLockDate")) {
               if (NOT listFindNoCase(arguments.exclude, "PeriodLockDate")) {
-                myStruct.PeriodLockDate=getPeriodLockDate();
+                myStruct["PeriodLockDate"]=getPeriodLockDate();
               }
             }
             if (structKeyExists(variables.instance,"EndOfYearLockDate")) {
               if (NOT listFindNoCase(arguments.exclude, "EndOfYearLockDate")) {
-                myStruct.EndOfYearLockDate=getEndOfYearLockDate();
+                myStruct["EndOfYearLockDate"]=getEndOfYearLockDate();
               }
             }
             if (structKeyExists(variables.instance,"CreatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "CreatedDateUTC")) {
-                myStruct.CreatedDateUTC=getCreatedDateUTC();
+                myStruct["CreatedDateUTC"]=getCreatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"Timezone")) {
               if (NOT listFindNoCase(arguments.exclude, "Timezone")) {
-                myStruct.Timezone=getTimezone();
+                myStruct["Timezone"]=getTimezone();
               }
             }
             if (structKeyExists(variables.instance,"OrganisationEntityType")) {
               if (NOT listFindNoCase(arguments.exclude, "OrganisationEntityType")) {
-                myStruct.OrganisationEntityType=getOrganisationEntityType();
+                myStruct["OrganisationEntityType"]=getOrganisationEntityType();
               }
             }
             if (structKeyExists(variables.instance,"ShortCode")) {
               if (NOT listFindNoCase(arguments.exclude, "ShortCode")) {
-                myStruct.ShortCode=getShortCode();
+                myStruct["ShortCode"]=getShortCode();
               }
             }
             if (structKeyExists(variables.instance,"LineOfBusiness")) {
               if (NOT listFindNoCase(arguments.exclude, "LineOfBusiness")) {
-                myStruct.LineOfBusiness=getLineOfBusiness();
+                myStruct["LineOfBusiness"]=getLineOfBusiness();
               }
             }
             if (structKeyExists(variables.instance,"Addresses")) {
               if (NOT listFindNoCase(arguments.exclude, "Addresses")) {
-                myStruct.Addresses=getAddresses();
+                myStruct["Addresses"]=getAddresses();
               }
             }
             if (structKeyExists(variables.instance,"Phones")) {
               if (NOT listFindNoCase(arguments.exclude, "Phones")) {
-                myStruct.Phones=getPhones();
+                myStruct["Phones"]=getPhones();
               }
             }
             if (structKeyExists(variables.instance,"ExternalLinks")) {
               if (NOT listFindNoCase(arguments.exclude, "ExternalLinks")) {
-                myStruct.ExternalLinks=getExternalLinks();
+                myStruct["ExternalLinks"]=getExternalLinks();
               }
             }
             if (structKeyExists(variables.instance,"PaymentTerms")) {
               if (NOT listFindNoCase(arguments.exclude, "PaymentTerms")) {
-                myStruct.PaymentTerms=getPaymentTerms();
+                myStruct["PaymentTerms"]=getPaymentTerms();
               }
             }
           }
@@ -352,9 +353,9 @@
           setCreatedDateUTC("");
         }
         if (structKeyExists(obj,"Timezone")) {
-          setTimezone(obj.Timezone);
+          this.setTimezone(obj.Timezone);
         } else {
-          setTimezone("");
+          this.setTimezone("");
         }
         if (structKeyExists(obj,"OrganisationEntityType")) {
           setOrganisationEntityType(obj.OrganisationEntityType);
@@ -824,7 +825,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.Addresses);i=i+1) {
-		          var item=createObject("component","cfc.model.Address").init().populate(arguments.Addresses[i]); 
+		          var item=createObject("component","Address").init(variables.xero).populate(arguments.Addresses[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>
@@ -845,7 +846,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.Phones);i=i+1) {
-		          var item=createObject("component","cfc.model.Phone").init().populate(arguments.Phones[i]); 
+		          var item=createObject("component","Phone").init(variables.xero).populate(arguments.Phones[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>
@@ -866,7 +867,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.ExternalLinks);i=i+1) {
-		          var item=createObject("component","cfc.model.ExternalLink").init().populate(arguments.ExternalLinks[i]); 
+		          var item=createObject("component","ExternalLink").init(variables.xero).populate(arguments.ExternalLinks[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>

--- a/model/Overpayment.cfc
+++ b/model/Overpayment.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Overpayment" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Overpayment" output="false" extends="xeroclient"
   hint="I am the Overpayment Class.">
 
 <!--- PROPERTIES --->
@@ -27,7 +27,8 @@
   <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Overpayment Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -70,108 +71,108 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.OverpaymentID=getOverpaymentID();
-            myStruct.Status=getStatus();
+            myStruct["OverpaymentID"]=getOverpaymentID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Type")) {
               if (NOT listFindNoCase(arguments.exclude, "Type")) {
-                myStruct.Type=getType();
+                myStruct["Type"]=getType();
               }
             }
             if (structKeyExists(variables.instance,"Contact")) {
               if (NOT listFindNoCase(arguments.exclude, "Contact")) {
-                myStruct.Contact=getContact();
+                myStruct["Contact"]=getContact();
               }
             }
             if (structKeyExists(variables.instance,"Date")) {
               if (NOT listFindNoCase(arguments.exclude, "Date")) {
-                myStruct.Date=getDate();
+                myStruct["Date"]=getDate();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"LineAmountTypes")) {
               if (NOT listFindNoCase(arguments.exclude, "LineAmountTypes")) {
-                myStruct.LineAmountTypes=getLineAmountTypes();
+                myStruct["LineAmountTypes"]=getLineAmountTypes();
               }
             }
             if (structKeyExists(variables.instance,"LineItems")) {
               if (NOT listFindNoCase(arguments.exclude, "LineItems")) {
-                myStruct.LineItems=getLineItems();
+                myStruct["LineItems"]=getLineItems();
               }
             }
             if (structKeyExists(variables.instance,"SubTotal")) {
               if (NOT listFindNoCase(arguments.exclude, "SubTotal")) {
-                myStruct.SubTotal=getSubTotal();
+                myStruct["SubTotal"]=getSubTotal();
               }
             }
             if (structKeyExists(variables.instance,"TotalTax")) {
               if (NOT listFindNoCase(arguments.exclude, "TotalTax")) {
-                myStruct.TotalTax=getTotalTax();
+                myStruct["TotalTax"]=getTotalTax();
               }
             }
             if (structKeyExists(variables.instance,"Total")) {
               if (NOT listFindNoCase(arguments.exclude, "Total")) {
-                myStruct.Total=getTotal();
+                myStruct["Total"]=getTotal();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyCode")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyCode")) {
-                myStruct.CurrencyCode=getCurrencyCode();
+                myStruct["CurrencyCode"]=getCurrencyCode();
               }
             }
             if (structKeyExists(variables.instance,"OverpaymentID")) {
               if (NOT listFindNoCase(arguments.exclude, "OverpaymentID")) {
-                //myStruct.OverpaymentID=getOverpaymentID();
+                //myStruct["OverpaymentID"]=getOverpaymentID();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyRate")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyRate")) {
-                myStruct.CurrencyRate=getCurrencyRate();
+                myStruct["CurrencyRate"]=getCurrencyRate();
               }
             }
             if (structKeyExists(variables.instance,"RemainingCredit")) {
               if (NOT listFindNoCase(arguments.exclude, "RemainingCredit")) {
-                myStruct.RemainingCredit=getRemainingCredit();
+                myStruct["RemainingCredit"]=getRemainingCredit();
               }
             }
             if (structKeyExists(variables.instance,"Allocations")) {
               if (NOT listFindNoCase(arguments.exclude, "Allocations")) {
-                myStruct.Allocations=getAllocations();
+                myStruct["Allocations"]=getAllocations();
               }
             }
             if (structKeyExists(variables.instance,"Payments")) {
               if (NOT listFindNoCase(arguments.exclude, "Payments")) {
-                myStruct.Payments=getPayments();
+                myStruct["Payments"]=getPayments();
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
-                myStruct.HasAttachments=getHasAttachments();
+                myStruct["HasAttachments"]=getHasAttachments();
               }
             }
             if (structKeyExists(variables.instance,"AppliedAmount")) {
               if (NOT listFindNoCase(arguments.exclude, "AppliedAmount")) {
-                myStruct.AppliedAmount=getAppliedAmount();
+                myStruct["AppliedAmount"]=getAppliedAmount();
               }
             }
             if (structKeyExists(variables.instance,"Amount")) {
               if (NOT listFindNoCase(arguments.exclude, "Amount")) {
-                myStruct.Amount=getAmount();
+                myStruct["Amount"]=getAmount();
               }
             }
             if (structKeyExists(variables.instance,"Invoice")) {
               if (NOT listFindNoCase(arguments.exclude, "Invoice")) {
-                myStruct.Invoice=getInvoice();
+                myStruct["Invoice"]=getInvoice();
               }
             }
 
@@ -456,7 +457,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.LineItems);i=i+1) {
-		          var item=createObject("component","cfc.model.LineItem").init().populate(arguments.LineItems[i]); 
+		          var item=createObject("component","LineItem").init(variables.xero).populate(arguments.LineItems[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>
@@ -581,7 +582,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.Allocations);i=i+1) {
-		          var item=createObject("component","cfc.model.Allocation").init().populate(arguments.Allocations[i]); 
+		          var item=createObject("component","Allocation").init(variables.xero).populate(arguments.Allocations[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>
@@ -602,7 +603,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.Payments);i=i+1) {
-		          var item=createObject("component","cfc.model.Payment").init().populate(arguments.Payments[i]); 
+		          var item=createObject("component","Payment").init(variables.xero).populate(arguments.Payments[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>

--- a/model/Payment.cfc
+++ b/model/Payment.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Payment" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Payment" output="false" extends="xeroclient"
   hint="I am the Payment Class.">
 
 <!--- PROPERTIES --->
@@ -24,7 +24,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Payment Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -68,93 +69,93 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.PaymentID=getPaymentID();
-            myStruct.Status=getStatus();
+            myStruct["PaymentID"]=getPaymentID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Invoice")) {
               if (NOT listFindNoCase(arguments.exclude, "Invoice")) {
-                myStruct.Invoice=getInvoice();
+                myStruct["Invoice"]=getInvoice();
               }
             }
             if (structKeyExists(variables.instance,"CreditNote")) {
               if (NOT listFindNoCase(arguments.exclude, "CreditNote")) {
-                myStruct.CreditNote=getCreditNote();
+                myStruct["CreditNote"]=getCreditNote();
               }
             }
             if (structKeyExists(variables.instance,"Prepayment")) {
               if (NOT listFindNoCase(arguments.exclude, "Prepayment")) {
-                myStruct.Prepayment=getPrepayment();
+                myStruct["Prepayment"]=getPrepayment();
               }
             }
             if (structKeyExists(variables.instance,"Overpayment")) {
               if (NOT listFindNoCase(arguments.exclude, "Overpayment")) {
-                myStruct.Overpayment=getOverpayment();
+                myStruct["Overpayment"]=getOverpayment();
               }
             }
             if (structKeyExists(variables.instance,"InvoiceNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "InvoiceNumber")) {
-                myStruct.InvoiceNumber=getInvoiceNumber();
+                myStruct["InvoiceNumber"]=getInvoiceNumber();
               }
             }
             if (structKeyExists(variables.instance,"CreditNoteNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "CreditNoteNumber")) {
-                myStruct.CreditNoteNumber=getCreditNoteNumber();
+                myStruct["CreditNoteNumber"]=getCreditNoteNumber();
               }
             }
             if (structKeyExists(variables.instance,"Account")) {
               if (NOT listFindNoCase(arguments.exclude, "Account")) {
-                myStruct.Account=getAccount();
+                myStruct["Account"]=getAccount();
               }
             }
             if (structKeyExists(variables.instance,"Code")) {
               if (NOT listFindNoCase(arguments.exclude, "Code")) {
-                myStruct.Code=getCode();
+                myStruct["Code"]=getCode();
               }
             }
             if (structKeyExists(variables.instance,"Date")) {
               if (NOT listFindNoCase(arguments.exclude, "Date")) {
-                myStruct.Date=getDate();
+                myStruct["Date"]=getDate();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyRate")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyRate")) {
-                myStruct.CurrencyRate=getCurrencyRate();
+                myStruct["CurrencyRate"]=getCurrencyRate();
               }
             }
             if (structKeyExists(variables.instance,"Amount")) {
               if (NOT listFindNoCase(arguments.exclude, "Amount")) {
-                myStruct.Amount=getAmount();
+                myStruct["Amount"]=getAmount();
               }
             }
             if (structKeyExists(variables.instance,"Reference")) {
               if (NOT listFindNoCase(arguments.exclude, "Reference")) {
-                myStruct.Reference=getReference();
+                myStruct["Reference"]=getReference();
               }
             }
             if (structKeyExists(variables.instance,"IsReconciled")) {
               if (NOT listFindNoCase(arguments.exclude, "IsReconciled")) {
-                myStruct.IsReconciled=getIsReconciled();
+                myStruct["IsReconciled"]=getIsReconciled();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"PaymentType")) {
               if (NOT listFindNoCase(arguments.exclude, "PaymentType")) {
-                myStruct.PaymentType=getPaymentType();
+                myStruct["PaymentType"]=getPaymentType();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"PaymentID")) {
               if (NOT listFindNoCase(arguments.exclude, "PaymentID")) {
-                myStruct.PaymentID=getPaymentID();
+                myStruct["PaymentID"]=getPaymentID();
               }
             }
           }

--- a/model/PaymentTerm.cfc
+++ b/model/PaymentTerm.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="PaymentTerm" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="PaymentTerm" output="false" extends="xeroclient"
   hint="I am the PaymentTerm Class.">
 
 <!--- PROPERTIES --->
@@ -9,7 +9,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the PaymentTerm Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -53,18 +54,18 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.PaymentTermID=getPaymentTermID();
-            myStruct.Status=getStatus();
+            myStruct["PaymentTermID"]=getPaymentTermID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Day")) {
               if (NOT listFindNoCase(arguments.exclude, "Day")) {
-                myStruct.Day=getDay();
+                myStruct["Day"]=getDay();
               }
             }
             if (structKeyExists(variables.instance,"Type")) {
               if (NOT listFindNoCase(arguments.exclude, "Type")) {
-                myStruct.Type=getType();
+                myStruct["Type"]=getType();
               }
             }
           }

--- a/model/PaymentTerms.cfc
+++ b/model/PaymentTerms.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="PaymentTerms" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="PaymentTerms" output="false" extends="xeroclient"
   hint="I am the PaymentTerms Class.">
 
 <!--- PROPERTIES --->
@@ -9,7 +9,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the PaymentTerms Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -53,18 +54,18 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.PaymentTermsID=getPaymentTermsID();
-            myStruct.Status=getStatus();
+            myStruct["PaymentTermsID"]=getPaymentTermsID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Bills")) {
               if (NOT listFindNoCase(arguments.exclude, "Bills")) {
-                myStruct.Bills=getBills();
+                myStruct["Bills"]=getBills();
               }
             }
             if (structKeyExists(variables.instance,"Sales")) {
               if (NOT listFindNoCase(arguments.exclude, "Sales")) {
-                myStruct.Sales=getSales();
+                myStruct["Sales"]=getSales();
               }
             }
           }

--- a/model/Phone.cfc
+++ b/model/Phone.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Phone" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Phone" output="false" extends="xeroclient"
   hint="I am the Phone Class.">
 
 <!--- PROPERTIES --->
@@ -10,7 +10,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Phone Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -54,27 +55,27 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.PhoneID=getPhoneID();
-            myStruct.Status=getStatus();
+            myStruct["PhoneID"]=getPhoneID();
+            myStruct["Status"]=getStatus();
           } else {
             if (structKeyExists(variables.instance,"PhoneType")) {
               if (NOT listFindNoCase(arguments.exclude, "PhoneType")) {
-                myStruct.PhoneType=getPhoneType();
+                myStruct["PhoneType"]=getPhoneType();
               }
             }
             if (structKeyExists(variables.instance,"PhoneNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "PhoneNumber")) {
-                myStruct.PhoneNumber=getPhoneNumber();
+                myStruct["PhoneNumber"]=getPhoneNumber();
               }
             }
             if (structKeyExists(variables.instance,"PhoneAreaCode")) {
               if (NOT listFindNoCase(arguments.exclude, "PhoneAreaCode")) {
-                myStruct.PhoneAreaCode=getPhoneAreaCode();
+                myStruct["PhoneAreaCode"]=getPhoneAreaCode();
               }
             }
             if (structKeyExists(variables.instance,"PhoneCountryCode")) {
               if (NOT listFindNoCase(arguments.exclude, "PhoneCountryCode")) {
-                myStruct.PhoneCountryCode=getPhoneCountryCode();
+                myStruct["PhoneCountryCode"]=getPhoneCountryCode();
               }
             }
           }

--- a/model/Prepayment.cfc
+++ b/model/Prepayment.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Prepayment" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Prepayment" output="false" extends="xeroclient"
   hint="I am the Prepayment Class.">
 
 <!--- PROPERTIES --->
@@ -27,7 +27,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Prepayment Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -71,103 +72,103 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.PrepaymentID=getPrepaymentID();
-            myStruct.Status=getStatus();
+            myStruct["PrepaymentID"]=getPrepaymentID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Type")) {
               if (NOT listFindNoCase(arguments.exclude, "Type")) {
-                myStruct.Type=getType();
+                myStruct["Type"]=getType();
               }
             }
             if (structKeyExists(variables.instance,"Contact")) {
               if (NOT listFindNoCase(arguments.exclude, "Contact")) {
-                myStruct.Contact=getContact();
+                myStruct["Contact"]=getContact();
               }
             }
             if (structKeyExists(variables.instance,"Date")) {
               if (NOT listFindNoCase(arguments.exclude, "Date")) {
-                myStruct.Date=getDate();
+                myStruct["Date"]=getDate();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"LineAmountTypes")) {
               if (NOT listFindNoCase(arguments.exclude, "LineAmountTypes")) {
-                myStruct.LineAmountTypes=getLineAmountTypes();
+                myStruct["LineAmountTypes"]=getLineAmountTypes();
               }
             }
             if (structKeyExists(variables.instance,"LineItems")) {
               if (NOT listFindNoCase(arguments.exclude, "LineItems")) {
-                myStruct.LineItems=getLineItems();
+                myStruct["LineItems"]=getLineItems();
               }
             }
             if (structKeyExists(variables.instance,"SubTotal")) {
               if (NOT listFindNoCase(arguments.exclude, "SubTotal")) {
-                myStruct.SubTotal=getSubTotal();
+                myStruct["SubTotal"]=getSubTotal();
               }
             }
             if (structKeyExists(variables.instance,"TotalTax")) {
               if (NOT listFindNoCase(arguments.exclude, "TotalTax")) {
-                myStruct.TotalTax=getTotalTax();
+                myStruct["TotalTax"]=getTotalTax();
               }
             }
             if (structKeyExists(variables.instance,"Total")) {
               if (NOT listFindNoCase(arguments.exclude, "Total")) {
-                myStruct.Total=getTotal();
+                myStruct["Total"]=getTotal();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyCode")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyCode")) {
-                myStruct.CurrencyCode=getCurrencyCode();
+                myStruct["CurrencyCode"]=getCurrencyCode();
               }
             }
             if (structKeyExists(variables.instance,"PrepaymentID")) {
               if (NOT listFindNoCase(arguments.exclude, "PrepaymentID")) {
-                myStruct.PrepaymentID=getPrepaymentID();
+                myStruct["PrepaymentID"]=getPrepaymentID();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyRate")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyRate")) {
-                myStruct.CurrencyRate=getCurrencyRate();
+                myStruct["CurrencyRate"]=getCurrencyRate();
               }
             }
             if (structKeyExists(variables.instance,"RemainingCredit")) {
               if (NOT listFindNoCase(arguments.exclude, "RemainingCredit")) {
-                myStruct.RemainingCredit=getRemainingCredit();
+                myStruct["RemainingCredit"]=getRemainingCredit();
               }
             }
             if (structKeyExists(variables.instance,"Allocations")) {
               if (NOT listFindNoCase(arguments.exclude, "Allocations")) {
-                myStruct.Allocations=getAllocations();
+                myStruct["Allocations"]=getAllocations();
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
-                myStruct.HasAttachments=getHasAttachments();
+                myStruct["HasAttachments"]=getHasAttachments();
               }
             }
             if (structKeyExists(variables.instance,"AppliedAmount")) {
               if (NOT listFindNoCase(arguments.exclude, "AppliedAmount")) {
-                myStruct.AppliedAmount=getAppliedAmount();
+                myStruct["AppliedAmount"]=getAppliedAmount();
               }
             }
             if (structKeyExists(variables.instance,"Amount")) {
               if (NOT listFindNoCase(arguments.exclude, "Amount")) {
-                myStruct.Amount=getAmount();
+                myStruct["Amount"]=getAmount();
               }
             }
             if (structKeyExists(variables.instance,"Invoice")) {
               if (NOT listFindNoCase(arguments.exclude, "Invoice")) {
-                myStruct.Invoice=getInvoice();
+                myStruct["Invoice"]=getInvoice();
               }
             }
 
@@ -434,7 +435,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.LineItems);i=i+1) {
-		          var item=createObject("component","cfc.model.LineItem").init().populate(arguments.LineItems[i]); 
+		          var item=createObject("component","LineItem").init(variables.xero).populate(arguments.LineItems[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>
@@ -559,7 +560,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.Allocations);i=i+1) {
-		          var item=createObject("component","cfc.model.Allocation").init().populate(arguments.Allocations[i]); 
+		          var item=createObject("component","Allocation").init(variables.xero).populate(arguments.Allocations[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>

--- a/model/PurchaseOrder.cfc
+++ b/model/PurchaseOrder.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="PurchaseOrder" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="PurchaseOrder" output="false" extends="xeroclient"
   hint="I am the PurchaseOrder Class.">
 
 <!--- PROPERTIES --->
@@ -31,6 +31,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the PurchaseOrder Class.">
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
      <cfset temp = this.populate(StructNew())>
  
     <cfreturn this />
@@ -76,142 +78,142 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.PurchaseOrderID=getPurchaseOrderID();
-            myStruct.Status=getStatus();
+            myStruct["PurchaseOrderID"]=getPurchaseOrderID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Contact")) {
               if (NOT listFindNoCase(arguments.exclude, "Contact")) {
-                myStruct.Contact=getContact();
+                myStruct["Contact"]=getContact();
               }
             }
             if (structKeyExists(variables.instance,"LineItems")) {
               if (NOT listFindNoCase(arguments.exclude, "LineItems")) {
-                myStruct.LineItems=getLineItems();
+                myStruct["LineItems"]=getLineItems();
               }
             }
             if (structKeyExists(variables.instance,"Date")) {
               if (NOT listFindNoCase(arguments.exclude, "Date")) {
-                myStruct.Date=getDate();
+                myStruct["Date"]=getDate();
               }
             }
             if (structKeyExists(variables.instance,"DeliveryDate")) {
               if (NOT listFindNoCase(arguments.exclude, "DeliveryDate")) {
-                myStruct.DeliveryDate=getDeliveryDate();
+                myStruct["DeliveryDate"]=getDeliveryDate();
               }
             }
             if (structKeyExists(variables.instance,"LineAmountTypes")) {
               if (NOT listFindNoCase(arguments.exclude, "LineAmountTypes")) {
                 if(len(getLineAmountTypes()) GT 0) {
-                  myStruct.LineAmountTypes=getLineAmountTypes();
+                  myStruct["LineAmountTypes"]=getLineAmountTypes();
                 }
               }
             } 
             if (structKeyExists(variables.instance,"PurchaseOrderNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "PurchaseOrderNumber")) {
                 if(len(getPurchaseOrderNumber()) GT 0) {
-                  myStruct.PurchaseOrderNumber=getPurchaseOrderNumber();
+                  myStruct["PurchaseOrderNumber"]=getPurchaseOrderNumber();
                 }
               }
             }
             if (structKeyExists(variables.instance,"Reference")) {
               if (NOT listFindNoCase(arguments.exclude, "Reference")) {
-                myStruct.Reference=getReference();
+                myStruct["Reference"]=getReference();
               }
             }
             if (structKeyExists(variables.instance,"BrandingThemeID")) {
               if (NOT listFindNoCase(arguments.exclude, "BrandingThemeID")) {
                 if(len(getBrandingThemeID()) GT 0) {
-                  myStruct.BrandingThemeID=getBrandingThemeID();
+                  myStruct["BrandingThemeID"]=getBrandingThemeID();
                 }
               }
             }
             if (structKeyExists(variables.instance,"CurrencyCode")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyCode")) {
                if(len(getCurrencyCode()) GT 0) {
-                  myStruct.CurrencyCode=getCurrencyCode();
+                  myStruct["CurrencyCode"]=getCurrencyCode();
                 } 
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
                 if(len(getStatus()) GT 0) {
-                  myStruct.Status=getStatus();
+                  myStruct["Status"]=getStatus();
                 } 
               }
             }
             if (structKeyExists(variables.instance,"SentToContact")) {
               if (NOT listFindNoCase(arguments.exclude, "SentToContact")) {
                 if(len(getSentToContact()) GT 0) {
-                  myStruct.SentToContact=getSentToContact();
+                  myStruct["SentToContact"]=getSentToContact();
                 }
               }
             }
             if (structKeyExists(variables.instance,"DeliveryAddress")) {
               if (NOT listFindNoCase(arguments.exclude, "DeliveryAddress")) {
-                myStruct.DeliveryAddress=getDeliveryAddress();
+                myStruct["DeliveryAddress"]=getDeliveryAddress();
               }
             }
             if (structKeyExists(variables.instance,"AttentionTo")) {
               if (NOT listFindNoCase(arguments.exclude, "AttentionTo")) {
-                myStruct.AttentionTo=getAttentionTo();
+                myStruct["AttentionTo"]=getAttentionTo();
               }
             }
             if (structKeyExists(variables.instance,"Telephone")) {
               if (NOT listFindNoCase(arguments.exclude, "Telephone")) {
-                myStruct.Telephone=getTelephone();
+                myStruct["Telephone"]=getTelephone();
               }
             }
             if (structKeyExists(variables.instance,"DeliveryInstructions")) {
               if (NOT listFindNoCase(arguments.exclude, "DeliveryInstructions")) {
-                myStruct.DeliveryInstructions=getDeliveryInstructions();
+                myStruct["DeliveryInstructions"]=getDeliveryInstructions();
               }
             }
             if (structKeyExists(variables.instance,"ExpectedArrivalDate")) {
               if (NOT listFindNoCase(arguments.exclude, "ExpectedArrivalDate")) {
-                myStruct.ExpectedArrivalDate=getExpectedArrivalDate();
+                myStruct["ExpectedArrivalDate"]=getExpectedArrivalDate();
               }
             }
             if (structKeyExists(variables.instance,"PurchaseOrderID")) {
               if (NOT listFindNoCase(arguments.exclude, "PurchaseOrderID")) {
                 if(len(getPurchaseOrderID()) GT 0) {
-                  myStruct.PurchaseOrderID=getPurchaseOrderID();
+                  myStruct["PurchaseOrderID"]=getPurchaseOrderID();
                 }
               }
             }
             if (structKeyExists(variables.instance,"CurrencyRate")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyRate")) {
-                myStruct.CurrencyRate=getCurrencyRate();
+                myStruct["CurrencyRate"]=getCurrencyRate();
               }
             }
             if (structKeyExists(variables.instance,"SubTotal")) {
               if (NOT listFindNoCase(arguments.exclude, "SubTotal")) {
-                myStruct.SubTotal=getSubTotal();
+                myStruct["SubTotal"]=getSubTotal();
               }
             }
             if (structKeyExists(variables.instance,"TotalTax")) {
               if (NOT listFindNoCase(arguments.exclude, "TotalTax")) {
-                myStruct.TotalTax=getTotalTax();
+                myStruct["TotalTax"]=getTotalTax();
               }
             }
             if (structKeyExists(variables.instance,"Total")) {
               if (NOT listFindNoCase(arguments.exclude, "Total")) {
-                myStruct.Total=getTotal();
+                myStruct["Total"]=getTotal();
               }
             }
             if (structKeyExists(variables.instance,"TotalDiscount")) {
               if (NOT listFindNoCase(arguments.exclude, "TotalDiscount")) {
-                myStruct.TotalDiscount=getTotalDiscount();
+                myStruct["TotalDiscount"]=getTotalDiscount();
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
-                myStruct.HasAttachments=getHasAttachments();
+                myStruct["HasAttachments"]=getHasAttachments();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
           }
@@ -475,7 +477,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.LineItems);i=i+1) {
-		          var item=createObject("component","cfc.model.LineItem").init().populate(arguments.LineItems[i]); 
+		          var item=createObject("component","LineItem").init(variables.xero).populate(arguments.LineItems[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>

--- a/model/Receipt.cfc
+++ b/model/Receipt.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Receipt" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Receipt" output="false" extends="xeroclient"
   hint="I am the Receipt Class.">
 
 <!--- PROPERTIES --->
@@ -20,7 +20,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Receipt Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -64,73 +65,73 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.ReceiptID=getReceiptID();
-            myStruct.Status=getStatus();
+            myStruct["ReceiptID"]=getReceiptID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Date")) {
               if (NOT listFindNoCase(arguments.exclude, "Date")) {
-                myStruct.Date=getDate();
+                myStruct["Date"]=getDate();
               }
             }
             if (structKeyExists(variables.instance,"Lineitems")) {
               if (NOT listFindNoCase(arguments.exclude, "Lineitems")) {
-                myStruct.Lineitems=getLineitems();
+                myStruct["Lineitems"]=getLineitems();
               }
             }
             if (structKeyExists(variables.instance,"Reference")) {
               if (NOT listFindNoCase(arguments.exclude, "Reference")) {
-                myStruct.Reference=getReference();
+                myStruct["Reference"]=getReference();
               }
             }
             if (structKeyExists(variables.instance,"LineAmountTypes")) {
               if (NOT listFindNoCase(arguments.exclude, "LineAmountTypes")) {
-                myStruct.LineAmountTypes=getLineAmountTypes();
+                myStruct["LineAmountTypes"]=getLineAmountTypes();
               }
             }
             if (structKeyExists(variables.instance,"SubTotal")) {
               if (NOT listFindNoCase(arguments.exclude, "SubTotal")) {
-                myStruct.SubTotal=getSubTotal();
+                myStruct["SubTotal"]=getSubTotal();
               }
             }
             if (structKeyExists(variables.instance,"TotalTax")) {
               if (NOT listFindNoCase(arguments.exclude, "TotalTax")) {
-                myStruct.TotalTax=getTotalTax();
+                myStruct["TotalTax"]=getTotalTax();
               }
             }
             if (structKeyExists(variables.instance,"Total")) {
               if (NOT listFindNoCase(arguments.exclude, "Total")) {
-                myStruct.Total=getTotal();
+                myStruct["Total"]=getTotal();
               }
             }
             if (structKeyExists(variables.instance,"ReceiptID")) {
               if (NOT listFindNoCase(arguments.exclude, "ReceiptID")) {
-                myStruct.ReceiptID=getReceiptID();
+                myStruct["ReceiptID"]=getReceiptID();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"ReceiptNumber")) {
               if (NOT listFindNoCase(arguments.exclude, "ReceiptNumber")) {
-                myStruct.ReceiptNumber=getReceiptNumber();
+                myStruct["ReceiptNumber"]=getReceiptNumber();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
-                myStruct.HasAttachments=getHasAttachments();
+                myStruct["HasAttachments"]=getHasAttachments();
               }
             }
             if (structKeyExists(variables.instance,"Url")) {
               if (NOT listFindNoCase(arguments.exclude, "Url")) {
-                myStruct.Url=getUrl();
+                myStruct["Url"]=getUrl();
               }
             }
           }

--- a/model/RepeatingInvoice.cfc
+++ b/model/RepeatingInvoice.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="RepeatingInvoice" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="RepeatingInvoice" output="false" extends="xeroclient"
   hint="I am the RepeatingInvoice Class.">
 
 <!--- PROPERTIES --->
@@ -21,7 +21,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the RepeatingInvoice Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -65,78 +66,78 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.RepeatingInvoiceID=getRepeatingInvoiceID();
-            myStruct.Status=getStatus();
+            myStruct["RepeatingInvoiceID"]=getRepeatingInvoiceID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Type")) {
               if (NOT listFindNoCase(arguments.exclude, "Type")) {
-                myStruct.Type=getType();
+                myStruct["Type"]=getType();
               }
             }
             if (structKeyExists(variables.instance,"Contact")) {
               if (NOT listFindNoCase(arguments.exclude, "Contact")) {
-                myStruct.Contact=getContact();
+                myStruct["Contact"]=getContact();
               }
             }
             if (structKeyExists(variables.instance,"Schedule")) {
               if (NOT listFindNoCase(arguments.exclude, "Schedule")) {
-                myStruct.Schedule=getSchedule();
+                myStruct["Schedule"]=getSchedule();
               }
             }
             if (structKeyExists(variables.instance,"LineItems")) {
               if (NOT listFindNoCase(arguments.exclude, "LineItems")) {
-                myStruct.LineItems=getLineItems();
+                myStruct["LineItems"]=getLineItems();
               }
             }
             if (structKeyExists(variables.instance,"LineAmountTypes")) {
               if (NOT listFindNoCase(arguments.exclude, "LineAmountTypes")) {
-                myStruct.LineAmountTypes=getLineAmountTypes();
+                myStruct["LineAmountTypes"]=getLineAmountTypes();
               }
             }
             if (structKeyExists(variables.instance,"Reference")) {
               if (NOT listFindNoCase(arguments.exclude, "Reference")) {
-                myStruct.Reference=getReference();
+                myStruct["Reference"]=getReference();
               }
             }
             if (structKeyExists(variables.instance,"BrandingThemeID")) {
               if (NOT listFindNoCase(arguments.exclude, "BrandingThemeID")) {
-                myStruct.BrandingThemeID=getBrandingThemeID();
+                myStruct["BrandingThemeID"]=getBrandingThemeID();
               }
             }
             if (structKeyExists(variables.instance,"CurrencyCode")) {
               if (NOT listFindNoCase(arguments.exclude, "CurrencyCode")) {
-                myStruct.CurrencyCode=getCurrencyCode();
+                myStruct["CurrencyCode"]=getCurrencyCode();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"SubTotal")) {
               if (NOT listFindNoCase(arguments.exclude, "SubTotal")) {
-                myStruct.SubTotal=getSubTotal();
+                myStruct["SubTotal"]=getSubTotal();
               }
             }
             if (structKeyExists(variables.instance,"TotalTax")) {
               if (NOT listFindNoCase(arguments.exclude, "TotalTax")) {
-                myStruct.TotalTax=getTotalTax();
+                myStruct["TotalTax"]=getTotalTax();
               }
             }
             if (structKeyExists(variables.instance,"Total")) {
               if (NOT listFindNoCase(arguments.exclude, "Total")) {
-                myStruct.Total=getTotal();
+                myStruct["Total"]=getTotal();
               }
             }
             if (structKeyExists(variables.instance,"RepeatingInvoiceID")) {
               if (NOT listFindNoCase(arguments.exclude, "RepeatingInvoiceID")) {
-                myStruct.RepeatingInvoiceID=getRepeatingInvoiceID();
+                myStruct["RepeatingInvoiceID"]=getRepeatingInvoiceID();
               }
             }
             if (structKeyExists(variables.instance,"HasAttachments")) {
               if (NOT listFindNoCase(arguments.exclude, "HasAttachments")) {
-                myStruct.HasAttachments=getHasAttachments();
+                myStruct["HasAttachments"]=getHasAttachments();
               }
             }
           }
@@ -376,7 +377,7 @@
 			<cfscript>
         var arr = ArrayNew(1);
         for (var i=1;i LTE ArrayLen(arguments.LineItems);i=i+1) {
-          var item=createObject("component","cfc.model.LineItem").init().populate(arguments.LineItems[i]); 
+          var item=createObject("component","LineItem").init(variables.xero).populate(arguments.LineItems[i]); 
           ArrayAppend(arr,item);
         }
       </cfscript>

--- a/model/Report.cfc
+++ b/model/Report.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="BrandingTheme" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="BrandingTheme" output="false" extends="xeroclient"
   hint="I am the BrandingTheme Class.">
 
 <!--- PROPERTIES --->
@@ -13,7 +13,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the BrandingTheme Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -42,41 +43,41 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.ReportID=getReportID();
-            myStruct.Status=getStatus();
+            myStruct["ReportID"]=getReportID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"ReportID")) {
               if (NOT listFindNoCase(arguments.exclude, "ReportID")) {
-                myStruct.ReportID=getReportID();
+                myStruct["ReportID"]=getReportID();
               }
             }
             if (structKeyExists(variables.instance,"ReportName")) {
               if (NOT listFindNoCase(arguments.exclude, "ReportName")) {
-                myStruct.ReportName=getReportName();
+                myStruct["ReportName"]=getReportName();
               }
             }
             if (structKeyExists(variables.instance,"ReportDate")) {
               if (NOT listFindNoCase(arguments.exclude, "ReportDate")) {
-                myStruct.ReportDate=getReportDate();
+                myStruct["ReportDate"]=getReportDate();
               }
             }
             if (structKeyExists(variables.instance,"ReportType")) {
               if (NOT listFindNoCase(arguments.exclude, "ReportType")) {
-                myStruct.ReportType=getReportType();
+                myStruct["ReportType"]=getReportType();
               }
             }
             if (structKeyExists(variables.instance,"ReportTitles")) {
               if (NOT listFindNoCase(arguments.exclude, "ReportTitles")) {
                 if (ArrayLen(variables.instance.ReportTitles) GT 0) {
-                  myStruct.ReportTitles=getReportTitles();
+                  myStruct["ReportTitles"]=getReportTitles();
                 }
               }
             }
             if (structKeyExists(variables.instance,"Rows")) {
               if (NOT listFindNoCase(arguments.exclude, "Rows")) {
                 if (ArrayLen(variables.instance.Rows) GT 0) {
-                  myStruct.Rows=getRows();
+                  myStruct["Rows"]=getRows();
                 }
               }
             }

--- a/model/Schedule.cfc
+++ b/model/Schedule.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="Schedule" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="Schedule" output="false" extends="xeroclient"
   hint="I am the Schedule Class.">
 
 <!--- PROPERTIES --->
@@ -14,7 +14,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the Schedule Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -58,43 +59,43 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.ScheduleID=getScheduleID();
-            myStruct.Status=getStatus();
+            myStruct["ScheduleID"]=getScheduleID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Period")) {
               if (NOT listFindNoCase(arguments.exclude, "Period")) {
-                myStruct.Period=getPeriod();
+                myStruct["Period"]=getPeriod();
               }
             }
             if (structKeyExists(variables.instance,"Unit")) {
               if (NOT listFindNoCase(arguments.exclude, "Unit")) {
-                myStruct.Unit=getUnit();
+                myStruct["Unit"]=getUnit();
               }
             }
             if (structKeyExists(variables.instance,"DueDate")) {
               if (NOT listFindNoCase(arguments.exclude, "DueDate")) {
-                myStruct.DueDate=getDueDate();
+                myStruct["DueDate"]=getDueDate();
               }
             }
             if (structKeyExists(variables.instance,"DueDateType")) {
               if (NOT listFindNoCase(arguments.exclude, "DueDateType")) {
-                myStruct.DueDateType=getDueDateType();
+                myStruct["DueDateType"]=getDueDateType();
               }
             }
             if (structKeyExists(variables.instance,"StartDate")) {
               if (NOT listFindNoCase(arguments.exclude, "StartDate")) {
-                myStruct.StartDate=getStartDate();
+                myStruct["StartDate"]=getStartDate();
               }
             }
             if (structKeyExists(variables.instance,"NextScheduledDate")) {
               if (NOT listFindNoCase(arguments.exclude, "NextScheduledDate")) {
-                myStruct.NextScheduledDate=getNextScheduledDate();
+                myStruct["NextScheduledDate"]=getNextScheduledDate();
               }
             }
             if (structKeyExists(variables.instance,"EndDate")) {
               if (NOT listFindNoCase(arguments.exclude, "EndDate")) {
-                myStruct.EndDate=getEndDate();
+                myStruct["EndDate"]=getEndDate();
               }
             }
           }

--- a/model/TaxComponent.cfc
+++ b/model/TaxComponent.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="TaxComponent" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="TaxComponent" output="false" extends="xeroclient"
   hint="I am the TaxComponent Class.">
 
 <!--- PROPERTIES --->
@@ -11,7 +11,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the TaxComponent Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -55,28 +56,28 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.TaxComponentID=getTaxComponentID();
-            myStruct.Status=getStatus();
+            myStruct["TaxComponentID"]=getTaxComponentID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Name")) {
               if (NOT listFindNoCase(arguments.exclude, "Name")) {
-                myStruct.Name=getName();
+                myStruct["Name"]=getName();
               }
             }
             if (structKeyExists(variables.instance,"Rate")) {
               if (NOT listFindNoCase(arguments.exclude, "Rate")) {
-                myStruct.Rate=getRate();
+                myStruct["Rate"]=getRate();
               }
             }
             if (structKeyExists(variables.instance,"IsCompound")) {
               if (NOT listFindNoCase(arguments.exclude, "IsCompound")) {
-                myStruct.IsCompound=getIsCompound();
+                myStruct["IsCompound"]=getIsCompound();
               }
             }
             if (structKeyExists(variables.instance,"IsNonRecoverable")) {
               if (NOT listFindNoCase(arguments.exclude, "IsNonRecoverable")) {
-                myStruct.IsNonRecoverable=getIsNonRecoverable();
+                myStruct["IsNonRecoverable"]=getIsNonRecoverable();
               }
             }
           }

--- a/model/TaxRate.cfc
+++ b/model/TaxRate.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="TaxRate" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="TaxRate" output="false" extends="xeroclient"
   hint="I am the TaxRate Class.">
 
 <!--- PROPERTIES --->
@@ -19,7 +19,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the TaxRate Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -63,68 +64,68 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.Name=getName();
-            myStruct.Status=getStatus();
+            myStruct["Name"]=getName();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"Name")) {
               if (NOT listFindNoCase(arguments.exclude, "Name")) {
-                myStruct.Name=getName();
+                myStruct["Name"]=getName();
               }
             }
             if (structKeyExists(variables.instance,"TaxType")) {
               if (NOT listFindNoCase(arguments.exclude, "TaxType")) {
-                myStruct.TaxType=getTaxType();
+                myStruct["TaxType"]=getTaxType();
               }
             }
             if (structKeyExists(variables.instance,"TaxComponents")) {
               if (NOT listFindNoCase(arguments.exclude, "TaxComponents")) {
-                myStruct.TaxComponents=getTaxComponents();
+                myStruct["TaxComponents"]=getTaxComponents();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"ReportTaxType")) {
               if (NOT listFindNoCase(arguments.exclude, "ReportTaxType")) {
-                myStruct.ReportTaxType=getReportTaxType();
+                myStruct["ReportTaxType"]=getReportTaxType();
               }
             }
             if (structKeyExists(variables.instance,"CanApplyToAssets")) {
               if (NOT listFindNoCase(arguments.exclude, "CanApplyToAssets")) {
-                myStruct.CanApplyToAssets=getCanApplyToAssets();
+                myStruct["CanApplyToAssets"]=getCanApplyToAssets();
               }
             }
             if (structKeyExists(variables.instance,"CanApplyToEquity")) {
               if (NOT listFindNoCase(arguments.exclude, "CanApplyToEquity")) {
-                myStruct.CanApplyToEquity=getCanApplyToEquity();
+                myStruct["CanApplyToEquity"]=getCanApplyToEquity();
               }
             }
             if (structKeyExists(variables.instance,"CanApplyToExpenses")) {
               if (NOT listFindNoCase(arguments.exclude, "CanApplyToExpenses")) {
-                myStruct.CanApplyToExpenses=getCanApplyToExpenses();
+                myStruct["CanApplyToExpenses"]=getCanApplyToExpenses();
               }
             }
             if (structKeyExists(variables.instance,"CanApplyToLiabilities")) {
               if (NOT listFindNoCase(arguments.exclude, "CanApplyToLiabilities")) {
-                myStruct.CanApplyToLiabilities=getCanApplyToLiabilities();
+                myStruct["CanApplyToLiabilities"]=getCanApplyToLiabilities();
               }
             }
             if (structKeyExists(variables.instance,"CanApplyToRevenue")) {
               if (NOT listFindNoCase(arguments.exclude, "CanApplyToRevenue")) {
-                myStruct.CanApplyToRevenue=getCanApplyToRevenue();
+                myStruct["CanApplyToRevenue"]=getCanApplyToRevenue();
               }
             }
             if (structKeyExists(variables.instance,"DisplayTaxRate")) {
               if (NOT listFindNoCase(arguments.exclude, "DisplayTaxRate")) {
-                myStruct.DisplayTaxRate=getDisplayTaxRate();
+                myStruct["DisplayTaxRate"]=getDisplayTaxRate();
               }
             }
             if (structKeyExists(variables.instance,"EffectiveRate")) {
               if (NOT listFindNoCase(arguments.exclude, "EffectiveRate")) {
-                myStruct.EffectiveRate=getEffectiveRate();
+                myStruct["EffectiveRate"]=getEffectiveRate();
               }
             }
           }
@@ -332,7 +333,7 @@
 			<cfscript>
 		        var arr = ArrayNew(1);
 		        for (var i=1;i LTE ArrayLen(arguments.TaxComponents);i=i+1) {
-		          var item=createObject("component","cfc.model.TaxComponent").init().populate(arguments.TaxComponents[i]); 
+		          var item=createObject("component","TaxComponent").init(variables.xero).populate(arguments.TaxComponents[i]); 
 		          ArrayAppend(arr,item);
 		        }
 		      </cfscript>

--- a/model/TrackingCategory.cfc
+++ b/model/TrackingCategory.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="TrackingCategory" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="TrackingCategory" output="false" extends="xeroclient"
   hint="I am the TrackingCategory Class.">
 
 <!--- PROPERTIES --->
@@ -12,7 +12,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the TrackingCategory Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -56,28 +57,28 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.TrackingCategoryID=getTrackingCategoryID();
-            myStruct.Status=getStatus();
+            myStruct["TrackingCategoryID"]=getTrackingCategoryID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"TrackingCategoryID")) {
               if (NOT listFindNoCase(arguments.exclude, "TrackingCategoryID")) {
-                myStruct.TrackingCategoryID=getTrackingCategoryID();
+                myStruct["TrackingCategoryID"]=getTrackingCategoryID();
               }
             }
             if (structKeyExists(variables.instance,"Name")) {
               if (NOT listFindNoCase(arguments.exclude, "Name")) {
-                myStruct.Name=getName();
+                myStruct["Name"]=getName();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"Options")) {
               if (NOT listFindNoCase(arguments.exclude, "Options")) {
-                myStruct.Options=getOptions();
+                myStruct["Options"]=getOptions();
               }
             }
           }
@@ -290,7 +291,7 @@
        <cfscript>
             var arr = ArrayNew(1);
             for (var i=1;i LTE ArrayLen(arguments.Options);i=i+1) {
-              var item=createObject("component","cfc.model.TrackingOption").init().populate(arguments.Options[i]); 
+              var item=createObject("component","TrackingOption").init(variables.xero).populate(arguments.Options[i]); 
               ArrayAppend(arr,item);
             }
       </cfscript>

--- a/model/TrackingOption.cfc
+++ b/model/TrackingOption.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="TrackingOption" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="TrackingOption" output="false" extends="xeroclient"
   hint="I am the TrackingOption Class.">
 
 <!--- PROPERTIES --->
@@ -11,7 +11,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the TrackingOption Class.">
-      
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
     <cfreturn this />
   </cffunction>
 
@@ -55,28 +56,28 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.TrackingOptionID=getTrackingOptionID();
-            myStruct.Status=getStatus();
+            myStruct["TrackingOptionID"]=getTrackingOptionID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"TrackingOptionID")) {
               if (NOT listFindNoCase(arguments.exclude, "TrackingOptionID")) {
-                myStruct.TrackingOptionID=getTrackingOptionID();
+                myStruct["TrackingOptionID"]=getTrackingOptionID();
               }
             }
             if (structKeyExists(variables.instance,"Name")) {
               if (NOT listFindNoCase(arguments.exclude, "Name")) {
-                myStruct.Name=getName();
+                myStruct["Name"]=getName();
               }
             }
             if (structKeyExists(variables.instance,"Status")) {
               if (NOT listFindNoCase(arguments.exclude, "Status")) {
-                myStruct.Status=getStatus();
+                myStruct["Status"]=getStatus();
               }
             }
             if (structKeyExists(variables.instance,"TrackingCategoryID")) {
               if (NOT listFindNoCase(arguments.exclude, "TrackingCategoryID")) {
-                myStruct.TrackingCategoryID=getTrackingCategoryID();
+                myStruct["TrackingCategoryID"]=getTrackingCategoryID();
               }
             }
           }

--- a/model/User.cfc
+++ b/model/User.cfc
@@ -1,4 +1,4 @@
-<cfcomponent displayname="User" output="false" extends="cfc.xeroclient"
+<cfcomponent displayname="User" output="false" extends="xeroclient"
   hint="I am the User Class.">
 
 <!--- PROPERTIES --->
@@ -14,6 +14,8 @@
 <!--- INIT --->
   <cffunction name="init" access="public" output="false"
     returntype="any" hint="I am the constructor method for the User Class.">
+    <cfargument name="xero" type="any">
+    <cfset variables.xero = arguments.xero>
       <cfset populate(StructNew())>
     <cfreturn this />
   </cffunction>
@@ -58,43 +60,43 @@
         <cfscript>
           myStruct=StructNew();
           if (archive) {
-            myStruct.UserID=getUserID();
-            myStruct.Status=getStatus();
+            myStruct["UserID"]=getUserID();
+            myStruct["Status"]=getStatus();
           } else {
 
             if (structKeyExists(variables.instance,"UserID")) {
               if (NOT listFindNoCase(arguments.exclude, "UserID")) {
-                myStruct.UserID=getUserID();
+                myStruct["UserID"]=getUserID();
               }
             }
             if (structKeyExists(variables.instance,"EmailAddress")) {
               if (NOT listFindNoCase(arguments.exclude, "EmailAddress")) {
-                myStruct.EmailAddress=getEmailAddress();
+                myStruct["EmailAddress"]=getEmailAddress();
               }
             }
             if (structKeyExists(variables.instance,"FirstName")) {
               if (NOT listFindNoCase(arguments.exclude, "FirstName")) {
-                myStruct.FirstName=getFirstName();
+                myStruct["FirstName"]=getFirstName();
               }
             }
             if (structKeyExists(variables.instance,"LastName")) {
               if (NOT listFindNoCase(arguments.exclude, "LastName")) {
-                myStruct.LastName=getLastName();
+                myStruct["LastName"]=getLastName();
               }
             }
             if (structKeyExists(variables.instance,"UpdatedDateUTC")) {
               if (NOT listFindNoCase(arguments.exclude, "UpdatedDateUTC")) {
-                myStruct.UpdatedDateUTC=getUpdatedDateUTC();
+                myStruct["UpdatedDateUTC"]=getUpdatedDateUTC();
               }
             }
             if (structKeyExists(variables.instance,"IsSubscriber")) {
               if (NOT listFindNoCase(arguments.exclude, "IsSubscriber")) {
-                myStruct.IsSubscriber=getIsSubscriber();
+                myStruct["IsSubscriber"]=getIsSubscriber();
               }
             }
             if (structKeyExists(variables.instance,"OrganisationRole")) {
               if (NOT listFindNoCase(arguments.exclude, "OrganisationRole")) {
-                myStruct.OrganisationRole=getOrganisationRole();
+                myStruct["OrganisationRole"]=getOrganisationRole();
               }
             }
           }

--- a/model/xeroclient.cfc
+++ b/model/xeroclient.cfc
@@ -1,8 +1,10 @@
 
 <cfcomponent displayname="xeroclient">
 
+	<cfset variables.xero = "">
+
 	<cffunction name="getBaseURL" access="public" returntype="string">
-		<cfset variables.baseUrl = "#application.config.ApiBaseUrl##application.config.ApiEndpointPath#"> 
+		<cfset variables.baseUrl = "#variables.xero.config.ApiBaseUrl##variables.xero.config.ApiEndpointPath#"> 
 		
 		<cfreturn variables.baseUrl>
 	</cffunction>
@@ -58,7 +60,7 @@
 			</cfif>
 		</cfif>
 		
-		<cfset oRequestResult = CreateObject("component", "cfc.xero").init().requestData(
+		<cfset oRequestResult = variables.xero.requestData(
 			sResourceEndpoint = this.getBaseURL() & resource,
 			stParameters= this.getParameters(),
 			sAccept = arguments.accept,
@@ -104,7 +106,7 @@
 			</cfif>
 		</cfif>
 
-		<cfset oRequestResult = CreateObject("component", "cfc.xero").init().requestData(
+		<cfset oRequestResult = variables.xero.requestData(
 			sResourceEndpoint = this.getBaseURL() & resource,
 			stParameters= this.getParameters(),
 			sAccept = arguments.accept,
@@ -137,7 +139,7 @@
 
 		<cfset resource = arguments.endpoint & "/" & arguments.id>
 
-		<cfset oRequestResult = CreateObject("component", "cfc.xero").init().requestData(
+		<cfset oRequestResult = variables.xero.requestData(
 			sResourceEndpoint = this.getBaseURL() & resource,
 			stParameters= this.getParameters(),
 			sAccept = arguments.accept,
@@ -177,7 +179,7 @@
 			</cfif>
 		</cfif>
 
-		<cfset oRequestResult = CreateObject("component", "cfc.xero").init().requestData(
+		<cfset oRequestResult = variables.xero.requestData(
 			sResourceEndpoint = this.getBaseURL() & resource,
 			stParameters= this.getParameters(),
 			sAccept = arguments.accept,

--- a/model/xeroclient.cfc
+++ b/model/xeroclient.cfc
@@ -45,41 +45,41 @@
 		<cfargument name="child"  type="string" default="">
 		<cfargument name="childId"  type="string" default="">
 		<cfif len(arguments.id) GT 0> 
-			<cfset resource = arguments.endpoint & "/" & arguments.id>
+			<cfset local.resource = arguments.endpoint & "/" & arguments.id>
 		<cfelse>
-			<cfset resource = arguments.endpoint>
+			<cfset local.resource = arguments.endpoint>
 		</cfif>
 
-		<cfset child = arguments.child>
-		<cfset childId = arguments.childId>
+		<cfset local.child = arguments.child>
+		<cfset local.childId = arguments.childId>
 		
-		<cfif len(child) GT 0>
-			<cfset resource = resource & "/" & child>
-			<cfif len(childId) GT 0>
-				<cfset resource = resource & "/" & childId>
+		<cfif len(local.child) GT 0>
+			<cfset local.resource = local.resource & "/" & local.child>
+			<cfif len(local.childId) GT 0>
+				<cfset local.resource = local.resource & "/" & local.childId>
 			</cfif>
 		</cfif>
 		
-		<cfset oRequestResult = variables.xero.requestData(
-			sResourceEndpoint = this.getBaseURL() & resource,
+		<cfset local.oRequestResult = variables.xero.requestData(
+			sResourceEndpoint = this.getBaseURL() & local.resource,
 			stParameters= this.getParameters(),
 			sAccept = arguments.accept,
 			sMethod = "GET",
 			sIfModifiedSince = this.getModifiedSince())>
 
-		<cfif NOT isJSON(oRequestResult["RESPONSE"])>
-			<cfthrow errorCode='401' message="#oRequestResult["RESPONSE"]#" Type='Application'>
+		<cfif NOT isJSON(local.oRequestResult["RESPONSE"])>
+			<cfthrow errorCode='401' message="#local.oRequestResult["RESPONSE"]#" Type='Application'>
 		</cfif>
 
-		<cfset rawResult = deserializeJson(oRequestResult["RESPONSE"])>
+		<cfset local.rawResult = deserializeJson(local.oRequestResult["RESPONSE"])>
 
-		<cfif structKeyExists(rawResult,"ErrorNumber")>
-			<cfthrow errorCode='400' message="#rawResult["Message"]#" Type='#rawResult["Type"]#' detail="#serializeJSON(rawResult["Elements"][1]["ValidationErrors"])#">
+		<cfif structKeyExists(local.rawResult,"ErrorNumber")>
+			<cfthrow errorCode='400' message="#local.rawResult["Message"]#" Type='#local.rawResult["Type"]#' detail="#serializeJSON(local.rawResult["Elements"][1]["ValidationErrors"])#">
 		</cfif>
 
-		<cfset variables.ArrayResult = deserializeJson(variables.oRequestResult["RESPONSE"])[arguments.endpoint]>
+		<cfset local.ArrayResult = deserializeJson(local.oRequestResult["RESPONSE"])[arguments.endpoint]>
 
-		<cfreturn variables.ArrayResult>
+		<cfreturn local.ArrayResult>
 	
 	</cffunction>
 
@@ -92,43 +92,43 @@
 		<cfargument name="id"  type="string" default="">
 		
 		<cfif len(arguments.id) GT 0> 
-			<cfset resource = arguments.endpoint & "/" & arguments.id>
+			<cfset local.resource = arguments.endpoint & "/" & arguments.id>
 		<cfelse>
-			<cfset resource = arguments.endpoint>
+			<cfset local.resource = arguments.endpoint>
 		</cfif>
-		<cfset child = arguments.child>
-		<cfset childId = arguments.childId>
+		<cfset local.child = arguments.child>
+		<cfset local.childId = arguments.childId>
 		
-		<cfif len(child) GT 0>
-			<cfset resource = resource & "/" & child>
-			<cfif len(childId) GT 0>
-				<cfset resource = resource & "/" & childId>
+		<cfif len(local.child) GT 0>
+			<cfset local.resource = local.resource & "/" & local.child>
+			<cfif len(local.childId) GT 0>
+				<cfset local.resource = local.resource & "/" & local.childId>
 			</cfif>
 		</cfif>
 
-		<cfset oRequestResult = variables.xero.requestData(
-			sResourceEndpoint = this.getBaseURL() & resource,
+		<cfset local.oRequestResult = variables.xero.requestData(
+			sResourceEndpoint = this.getBaseURL() & local.resource,
 			stParameters= this.getParameters(),
 			sAccept = arguments.accept,
 			sMethod = "PUT",
 			sBody = arguments.body)>
 
-		<cfif NOT isJSON(oRequestResult["RESPONSE"])>
-			<cfthrow errorCode='401' message="#oRequestResult["RESPONSE"]#" Type='Application'>
+		<cfif NOT isJSON(local.oRequestResult["RESPONSE"])>
+			<cfthrow errorCode='401' message="#local.oRequestResult["RESPONSE"]#" Type='Application'>
 		</cfif>
 
-		<cfset rawResult = deserializeJson(oRequestResult["RESPONSE"])>
+		<cfset local.rawResult = deserializeJson(local.oRequestResult["RESPONSE"])>
 
-		<cfif structKeyExists(rawResult,"ErrorNumber")>
-			<cfthrow errorCode='400' message="#rawResult["Message"]#" Type='#rawResult["Type"]#' detail="#serializeJSON(rawResult["Elements"][1]["ValidationErrors"])#">
+		<cfif structKeyExists(local.rawResult,"ErrorNumber")>
+			<cfthrow errorCode='400' message="#local.rawResult["Message"]#" Type='#local.rawResult["Type"]#' detail="#serializeJSON(local.rawResult["Elements"][1]["ValidationErrors"])#">
 		</cfif>
 
-		<cfif len(child) GT 0>
-			<cfset variables.result = deserializeJson(variables.oRequestResult["RESPONSE"])[arguments.child]>	
+		<cfif len(local.child) GT 0>
+			<cfset local.result = deserializeJson(local.oRequestResult["RESPONSE"])[arguments.child]>	
 		<cfelse>
-			<cfset variables.result = deserializeJson(variables.oRequestResult["RESPONSE"])[arguments.endpoint]>
+			<cfset local.result = deserializeJson(local.oRequestResult["RESPONSE"])[arguments.endpoint]>
 		</cfif>
-		<cfreturn variables.result>	
+		<cfreturn local.result>	
 	</cffunction>
 
 	<cffunction name="post" access="public" returntype="array">
@@ -137,27 +137,27 @@
 		<cfargument name="body"  type="string" default="">
 		<cfargument name="id"  type="string" default="">
 
-		<cfset resource = arguments.endpoint & "/" & arguments.id>
+		<cfset local.resource = arguments.endpoint & "/" & arguments.id>
 
-		<cfset oRequestResult = variables.xero.requestData(
-			sResourceEndpoint = this.getBaseURL() & resource,
+		<cfset local.oRequestResult = variables.xero.requestData(
+			sResourceEndpoint = this.getBaseURL() & local.resource,
 			stParameters= this.getParameters(),
 			sAccept = arguments.accept,
 			sMethod = "POST",
 			sBody = arguments.body)>
 
-		<cfif NOT isJSON(oRequestResult["RESPONSE"])>
-			<cfthrow errorCode='401' message="#oRequestResult["RESPONSE"]#" Type='Application'>
+		<cfif NOT isJSON(local.oRequestResult["RESPONSE"])>
+			<cfthrow errorCode='401' message="#local.oRequestResult["RESPONSE"]#" Type='Application'>
 		</cfif>
 	
-		<cfset rawResult = deserializeJson(oRequestResult["RESPONSE"])>
+		<cfset local.rawResult = deserializeJson(local.oRequestResult["RESPONSE"])>
 
-		<cfif structKeyExists(rawResult,"ErrorNumber")>
-			<cfthrow errorCode='400' message="#rawResult["Message"]#" Type='#rawResult["Type"]#' detail="#serializeJSON(rawResult["Elements"][1]["ValidationErrors"])#">			
+		<cfif structKeyExists(local.rawResult,"ErrorNumber")>
+			<cfthrow errorCode='400' message="#local.rawResult["Message"]#" Type='#local.rawResult["Type"]#' detail="#serializeJSON(local.rawResult["Elements"][1]["ValidationErrors"])#">			
 		</cfif>
 
-		<cfset variables.result = deserializeJson(variables.oRequestResult["RESPONSE"])[arguments.endpoint]>
-		<cfreturn variables.result>
+		<cfset local.result = deserializeJson(local.oRequestResult["RESPONSE"])[arguments.endpoint]>
+		<cfreturn local.result>
 	</cffunction>
 
 	<cffunction name="delete" access="public" returntype="any">
@@ -167,56 +167,56 @@
 		<cfargument name="id"  type="string" default="">
 		<cfargument name="child"  type="string" default="">
 		<cfargument name="childId"  type="string" default="">
-		<cfset resource = arguments.endpoint & "/" & arguments.id>
+		<cfset local.resource = arguments.endpoint & "/" & arguments.id>
 
-		<cfset child = arguments.child>
-		<cfset childId = arguments.childId>
+		<cfset local.child = arguments.child>
+		<cfset local.childId = arguments.childId>
 		
-		<cfif len(child) GT 0>
-			<cfset resource = resource & "/" & child>
-			<cfif len(childId) GT 0>
-				<cfset resource = resource & "/" & childId>
+		<cfif len(local.child) GT 0>
+			<cfset local.resource = local.resource & "/" & local.child>
+			<cfif len(local.childId) GT 0>
+				<cfset local.resource = local.resource & "/" & local.childId>
 			</cfif>
 		</cfif>
 
-		<cfset oRequestResult = variables.xero.requestData(
-			sResourceEndpoint = this.getBaseURL() & resource,
+		<cfset local.oRequestResult = variables.xero.requestData(
+			sResourceEndpoint = this.getBaseURL() & local.resource,
 			stParameters= this.getParameters(),
 			sAccept = arguments.accept,
 			sMethod = "DELETE",
 			sBody = arguments.body)>
 
 
-		<cfif NOT isJSON(oRequestResult["RESPONSE"])>
-			<cfthrow errorCode='401' message="#oRequestResult["RESPONSE"]#" Type='Application'>
+		<cfif NOT isJSON(local.oRequestResult["RESPONSE"])>
+			<cfthrow errorCode='401' message="#local.oRequestResult["RESPONSE"]#" Type='Application'>
 		</cfif>
-		<cfif len(oRequestResult["RESPONSE"]) GT 0 >
-			<cfset rawResult = deserializeJson(oRequestResult["RESPONSE"])>
-			<cfif structKeyExists(rawResult,"ErrorNumber")>
-				<cfthrow errorCode='#rawResult["ErrorNumber"]#' message="#rawResult["Message"]#" Type='#rawResult["Type"]#'>
+		<cfif len(local.oRequestResult["RESPONSE"]) GT 0 >
+			<cfset local.rawResult = deserializeJson(local.oRequestResult["RESPONSE"])>
+			<cfif structKeyExists(local.rawResult,"ErrorNumber")>
+				<cfthrow errorCode='#local.rawResult["ErrorNumber"]#' message="#local.rawResult["Message"]#" Type='#local.rawResult["Type"]#'>
 			</cfif>
 
-			<cfif isJSON(variables.oRequestResult["RESPONSE"])>
-				<cfif StructKeyExists(rawResult,"Deleted")>
-					<cfset variables.result = StructNew()>
+			<cfif isJSON(local.oRequestResult["RESPONSE"])>
+				<cfif StructKeyExists(local.rawResult,"Deleted")>
+					<cfset local.result = StructNew()>
 				<cfelseif StructKeyExists(rawResult,arguments.endpoint)>
-					<cfset variables.result = deserializeJson(variables.oRequestResult["RESPONSE"])[arguments.endpoint]>
+					<cfset local.result = deserializeJson(local.oRequestResult["RESPONSE"])[arguments.endpoint]>
 				<cfelseif StructKeyExists(rawResult,arguments.child)>
-					<cfset variables.result = deserializeJson(variables.oRequestResult["RESPONSE"])[arguments.child]>
+					<cfset local.result = deserializeJson(local.oRequestResult["RESPONSE"])[arguments.child]>
 				<cfelse>
-					<cfthrow errorCode='400' message="#oRequestResult["RESPONSE"]["Message"]#" Type='#oRequestResult["RESPONSE"]["Type"]#' >	
+					<cfthrow errorCode='400' message="#local.oRequestResult["RESPONSE"]["Message"]#" Type='#local.oRequestResult["RESPONSE"]["Type"]#' >	
 					
 				</cfif>
 			<cfelse>
-				<cfset variables.result = StructNew()>
+				<cfset local.result = StructNew()>
 			</cfif>
 		<cfelse>
 
-			<cfset myStruct = StructNew()>
-			<cfset myStruct.foo = "bar">
-			<cfset variables.result = myStruct>
+			<cfset local.myStruct = StructNew()>
+			<cfset local.myStruct.foo = "bar">
+			<cfset local.result = myStruct>
 		</cfif>
-		<cfreturn variables.result>
+		<cfreturn local.result>
 	</cffunction>
 
 </cfcomponent>

--- a/storage.cfc
+++ b/storage.cfc
@@ -10,15 +10,19 @@
   <cfproperty name="timestamp" type="String" default="" />
   <cfproperty name="oauth_session_handle" type="String" default="" />
   <cfproperty name="oauth_expires_in" type="String" default="" />
+
+  <cfset variables.xero = "">
   
 <!--- INIT --->
 	<cffunction name="init" access="public" output="false" returntype="storage" hint="I am the constructor method for the Storage Class.">
+		<cfargument name="xero" type="any">
+		<cfset variables.xero = arguments.xero>
     	<cfreturn this />
   	</cffunction>
 
   	<cffunction name="getRequestOAuthToken" access="public" returntype="string">
 		<cfset variables.request_oauth_token = ""> 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset variables.request_oauth_token = session.stToken["request_oauth_token"]> 	
 		</cfif>
 		<cfreturn variables.request_oauth_token>
@@ -27,14 +31,14 @@
 	<cffunction name="setRequestOAuthToken" access="public" >
 		<cfargument name="request_oauth_token" required="true" type="String" default="" hint="I am a string of this object." />
 
-		<cfif application.config["AppType"] NEQ "Private">
+		<cfif variables.xero.config["AppType"] NEQ "Private">
 			<cfset session.stToken["request_oauth_token"] = arguments.request_oauth_token> 	
 		</cfif>
 	</cffunction>
 
 	<cffunction name="getRequestOAuthTokenSecret" access="public" returntype="string">
 		<cfset variables.request_oauth_token_secret = ""> 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset variables.request_oauth_token_secret = session.stToken["request_oauth_token_secret"]> 
 		</cfif>
 		<cfreturn variables.request_oauth_token_secret>
@@ -43,14 +47,14 @@
 	<cffunction name="setRequestOAuthTokenSecret" access="public" >
 		<cfargument name="request_oauth_token_secret" required="true" type="String" default="" hint="I am a string of this object." />
 
-		<cfif application.config["AppType"] NEQ "Private">
+		<cfif variables.xero.config["AppType"] NEQ "Private">
 			<cfset session.stToken["request_oauth_token_secret"] = arguments.request_oauth_token_secret> 	
 		</cfif>
 	</cffunction>
 
 	<cffunction name="getOAuthToken" access="public" returntype="string">
 		<cfset variables.oauth_token = ""> 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset variables.oauth_token = session.stToken["oauth_token"]> 	
 		</cfif>
 		<cfreturn variables.oauth_token>
@@ -59,14 +63,14 @@
 	<cffunction name="setOAuthToken" access="public" >
 		<cfargument name="oauth_token" required="true" type="String" default="" hint="I am a string of this object." />
 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset session.stToken["oauth_token"] = arguments.oauth_token> 	
 		</cfif>
 	</cffunction>
 
 	<cffunction name="getOAuthTokenSecret" access="public" returntype="string">
 		<cfset variables.oauth_token_secret = ""> 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset variables.oauth_token_secret = session.stToken["oauth_token_secret"]> 
 		</cfif>
 		<cfreturn variables.oauth_token_secret>
@@ -75,14 +79,14 @@
 	<cffunction name="setOAuthTokenSecret" access="public" >
 		<cfargument name="oauth_token_secret" required="true" type="String" default="" hint="I am a string of this object." />
 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset session.stToken["oauth_token_secret"] = arguments.oauth_token_secret> 	
 		</cfif>
 	</cffunction>
 
 	<cffunction name="getTimestamp" access="public" returntype="string">
 		<cfset variables.timestamp = ""> 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset variables.timestamp = session.stToken["timestamp"]> 	
 		</cfif>
 		<cfreturn variables.timestamp>
@@ -91,14 +95,14 @@
 	<cffunction name="setTimestamp" access="public" >
 		<cfargument name="timestamp" required="true" type="String" default="" hint="I am a string of this object." />
 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset session.stToken["timestamp"] = arguments.timestamp> 	
 		</cfif>
 	</cffunction>
 
 	<cffunction name="getOAuthExpiresIn" access="public" returntype="string">
 		<cfset variables.oauth_expires_in = ""> 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset variables.oauth_expires_in = session.stToken["oauth_expires_in"]> 
 		</cfif>
 		<cfreturn variables.oauth_expires_in>
@@ -107,14 +111,14 @@
 	<cffunction name="setOAuthExpiresIn" access="public" >
 		<cfargument name="oauth_expires_in" required="true" type="String" default="" hint="I am a string of this object." />
 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset session.stToken["oauth_expires_in"] = arguments.oauth_expires_in> 	
 		</cfif>
 	</cffunction>
 
 	<cffunction name="getOAuthSessionHandle" access="public" returntype="string">
 		<cfset variables.oauth_session_handle = ""> 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset variables.oauth_session_handle = session.stToken["oauth_session_handle"]> 
 		</cfif>
 		<cfreturn variables.oauth_session_handle>
@@ -123,14 +127,14 @@
 	<cffunction name="setOAuthSessionHandle" access="public" >
 		<cfargument name="oauth_session_handle" required="true" type="String" default="" hint="I am a string of this object." />
 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset session.stToken["oauth_session_handle"] = arguments.oauth_session_handle> 	
 		</cfif>
 	</cffunction>
 
 	<cffunction name="getVerifier" access="public" returntype="string">
 		<cfset variables.oauth_verifier = ""> 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset variables.oauth_verifier = session.stToken["oauth_verifier"]> 
 		</cfif>
 		<cfreturn variables.oauth_verifier>
@@ -139,7 +143,7 @@
 	<cffunction name="setVerifier" access="public" >
 		<cfargument name="oauth_verifier" required="true" type="String" default="" hint="I am a string of this object." />
 
-		<cfif application.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
+		<cfif variables.xero.config["AppType"] NEQ "Private" AND StructKeyExists(session, "stToken")>
 			<cfset session.stToken["oauth_verifier"] = arguments.oauth_verifier> 	
 		</cfif>
 	</cffunction>

--- a/storage.cfc
+++ b/storage.cfc
@@ -151,12 +151,12 @@
 	<cffunction name="saveRequestToken" access="public" >
 		<cfargument name="response" required="true" type="String" default="" hint="I am a string of this object." />
 
-		<cfloop list="#arguments.response#" index="elem" delimiters="&">  
-			<cfif #listFirst(elem,"=")# EQ "oauth_token">
-				<cfset this.setRequestOAuthToken(listLast(elem,"="))>
+		<cfloop list="#arguments.response#" index="local.elem" delimiters="&">  
+			<cfif #listFirst(local.elem,"=")# EQ "oauth_token">
+				<cfset this.setRequestOAuthToken(listLast(local.elem,"="))>
 			</cfif>
-			<cfif #listFirst(elem,"=")# EQ "oauth_token_secret">
-				<cfset this.setRequestOAuthTokenSecret(listLast(elem,"="))>
+			<cfif #listFirst(local.elem,"=")# EQ "oauth_token_secret">
+				<cfset this.setRequestOAuthTokenSecret(listLast(local.elem,"="))>
 			</cfif>
 		</cfloop>  
 	</cffunction>
@@ -164,15 +164,15 @@
 	<cffunction name="saveCallback" access="public" >
 		<cfargument name="response" required="true" type="String" default="" hint="I am a string of this object." />
 
-		<cfloop list="#arguments.response#" index="elem" delimiters="&">  
-			<cfif #listFirst(elem,"=")# EQ "oauth_token">
-				<cfset this.setOAuthToken(listLast(elem,"="))>
+		<cfloop list="#arguments.response#" index="local.elem" delimiters="&">  
+			<cfif #listFirst(local.elem,"=")# EQ "oauth_token">
+				<cfset this.setOAuthToken(listLast(local.elem,"="))>
 			</cfif>
-			<cfif #listFirst(elem,"=")# EQ "oauth_token_secret">
-				<cfset this.setOAuthTokenSecret(listLast(elem,"="))>
+			<cfif #listFirst(local.elem,"=")# EQ "oauth_token_secret">
+				<cfset this.setOAuthTokenSecret(listLast(local.elem,"="))>
 			</cfif>
-			<cfif #listFirst(elem,"=")# EQ "oauth_verifier">
-				<cfset this.setVerifier(listLast(elem,"="))>
+			<cfif #listFirst(local.elem,"=")# EQ "oauth_verifier">
+				<cfset this.setVerifier(listLast(local.elem,"="))>
 			</cfif>
 		</cfloop>  
 	</cffunction>
@@ -180,21 +180,21 @@
 	<cffunction name="saveAccessToken" access="public" >
 		<cfargument name="response" required="true" type="String" default="" hint="I am a string of this object." />
 
-		<cfloop list="#arguments.response#" index="elem" delimiters="&">  
-			<cfif #listFirst(elem,"=")# EQ "oauth_token">
-				<cfset this.setOAuthToken(listLast(elem,"="))>
+		<cfloop list="#arguments.response#" index="local.elem" delimiters="&">  
+			<cfif #listFirst(local.elem,"=")# EQ "oauth_token">
+				<cfset this.setOAuthToken(listLast(local.elem,"="))>
 			</cfif>
-			<cfif #listFirst(elem,"=")# EQ "oauth_token_secret">
-				<cfset this.setOAuthTokenSecret(listLast(elem,"="))>
+			<cfif #listFirst(local.elem,"=")# EQ "oauth_token_secret">
+				<cfset this.setOAuthTokenSecret(listLast(local.elem,"="))>
 			</cfif>
-			<cfif #listFirst(elem,"=")# EQ "oauth_verifier">
-				<cfset this.setVerifier(listLast(elem,"="))>
+			<cfif #listFirst(local.elem,"=")# EQ "oauth_verifier">
+				<cfset this.setVerifier(listLast(local.elem,"="))>
 			</cfif>
-			<cfif #listFirst(elem,"=")# EQ "oauth_session_handle">
-				<cfset this.setOAuthSessionHandle(listLast(elem,"="))>
+			<cfif #listFirst(local.elem,"=")# EQ "oauth_session_handle">
+				<cfset this.setOAuthSessionHandle(listLast(local.elem,"="))>
 			</cfif>
-			<cfif #listFirst(elem,"=")# EQ "oauth_expires_in">
-				<cfset this.setOAuthExpiresIn(listLast(elem,"="))>
+			<cfif #listFirst(local.elem,"=")# EQ "oauth_expires_in">
+				<cfset this.setOAuthExpiresIn(listLast(local.elem,"="))>
 			</cfif>
 		</cfloop>  
 	</cffunction>

--- a/xero.cfc
+++ b/xero.cfc
@@ -256,7 +256,7 @@ History:
 		<cfargument name="sOAuthToken" required="false" type="string" default="">
 		<cfargument name="sOAuthTokenSecret" required="false" type="string" default="">
 		<cfargument name="stParameters" required="false" type="struct" default="">
-		<cfargument name="sAccept" required="false" type="string" default="#application.xeroConfig.json["Accept"]#">
+		<cfargument name="sAccept" required="false" type="string" default="#this.config.json["Accept"]#">
 		<cfargument name="sIfModifiedSince" required="false" type="string" default="">
 		<cfargument name="sMethod" required="false" type="string" default="GET">
 		<cfargument name="sBody" required="false" type="string" default="">


### PR DESCRIPTION
Modified to remove mapping dependency; struct case is maintained without having to set serialization.preservecaseforstructkey and there is no hard coded config dependency.

The setup and structure has been changed slightly so the only component that needs to be initiated is xero.cfc, into which you pass the config.json path. The idea would be that this is ideally created as a singleton. You can obtain the models by calling the getModel("ModelName") function.